### PR TITLE
replaces C-style typedef struct with C++-style struct

### DIFF
--- a/src/node_osrm.cpp
+++ b/src/node_osrm.cpp
@@ -97,14 +97,14 @@ Handle<Value> Engine::New(const Arguments& args)
     return Undefined();
 }
 
-typedef struct {
+struct run_query_baton_t {
     uv_work_t request;
     Engine * machine;
     route_parameters_ptr params;
     bool error;
     std::string result;
     Persistent<Function> cb;
-} run_query_baton_t;
+};
 
 Handle<Value> Engine::route(const Arguments& args)
 {


### PR DESCRIPTION
- Not sure if there is a reason for this coming from Node. If this is a requirement, please close. If not, let's stay C++ all the way.

cc: @jfirebaugh 
