### PR TITLE
Stop stripping release builds

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -32,10 +32,7 @@
                 'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',
                 'DEAD_CODE_STRIPPING':'YES',
                 'GCC_INLINES_ARE_PRIVATE_EXTERN':'YES'
-              },
-              'ldflags': [
-                    '-Wl,-s'
-              ]
+              }
           }
       }
   }


### PR DESCRIPTION
We've been stripping linux binaries only because early on I experimented with this (to reduce binary size) and left it in. However I don't think binary size is much of a concern and the benefit to not stripping is being able to see some symbols from crash backtraces even for release builds.

Currently I'm seeing backtraces on linux that look like:

```
Thread 2 (LWP 3555):
#0  0x00007f58b4665fd0 in ?? ()
#1  0x00007f58b00008c8 in ?? ()
#2  0x00000000009775e5 in ?? ()
#3  0x00007f58b56bbda0 in ?? ()
#4  0x0000000000000001 in ?? ()
#5  0x00007f58b56bbda0 in ?? ()
#6  0x0000000000882ee7 in ?? ()
#7  0x00007f58b56bbe80 in ?? ()
#8  0x0000000000978788 in ?? ()
#9  0x0000000000000000 in ?? ()
```

Removing stripping may fix this and even if it is not the ultimate cause of what I'm seeing its a good idea anyway.