### PR TITLE
Reenable shared memory test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
 install:
 # set a few env settings for the static build script
 - NODE_MODULE_ROOT=`pwd`
-- export OSRM_RELEASE="v4.6.0"
+- export OSRM_RELEASE="v4.6.1"
 # WARNING: this script modifies the environment
 - source ./scripts/static_build.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## node-osrm changelog
 
+### 4.6.1
+
+ - Update OSRM to v4.6.1
+ - Fixes crash when using shared memory
+
 ### 4.6.0
 
  - Update OSRM to v4.6.0

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ berlin-latest.osrm.hsgr: berlin-latest.osrm
 	PATH="./lib/binding:${PATH}" && osrm-prepare berlin-latest.osrm -p test/data/car.lua
 
 test: berlin-latest.osrm.hsgr
+	PATH="./lib/binding:${PATH}" && osrm-datastore berlin-latest.osrm
 	npm test
 
 check: test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/Project-OSRM/node-osrm",
     "homepage": "http://project-osrm.org",
     "author": "Dane Springmeyer <springmeyer>",
-    "version": "4.6.0",
+    "version": "4.6.1",
     "main": "./lib/osrm.js",
     "bugs": {
         "email": "dane@mapbox.com",

--- a/test/osrm.test.js
+++ b/test/osrm.test.js
@@ -27,14 +27,19 @@ it('routes Berlin', function(done) {
     });
 });
 
-it('routes Berlin using shared memory', function(done) {
-    var osrm = new OSRM();
-    osrm.route({coordinates: [[52.519930,13.438640], [52.513191,13.415852]]}, function(err, route) {
-        assert.ifError(err);
-        assert.equal(route.status_message, 'Found route between points');
-        done();
-    });
-});
+if (process.platform === 'darwin') {
+  // shared memory does not work on Mac OS for now.
+  it.skip('routes Berlin using shared memory', function(done) {});
+} else {
+  it('routes Berlin using shared memory', function(done) {
+      var osrm = new OSRM();
+      osrm.route({coordinates: [[52.519930,13.438640], [52.513191,13.415852]]}, function(err, route) {
+          assert.ifError(err);
+          assert.equal(route.status_message, 'Found route between points');
+          done();
+      });
+  });
+}
 
 it('routes Berlin with options', function(done) {
     var osrm = new OSRM("berlin-latest.osrm");

--- a/test/osrm.test.js
+++ b/test/osrm.test.js
@@ -27,7 +27,7 @@ it('routes Berlin', function(done) {
     });
 });
 
-it.skip('routes Berlin using shared memory', function(done) {
+it('routes Berlin using shared memory', function(done) {
     var osrm = new OSRM();
     osrm.route({coordinates: [[52.519930,13.438640], [52.513191,13.415852]]}, function(err, route) {
         assert.ifError(err);


### PR DESCRIPTION
This re-enables the shared memory test. Needs soon to be released OSRM ```4.6.1```, as the default parameter for OSRM previously was to use shared memory, but the last release accidentally changed that.