### PR TITLE
Add compression flag to match method

### DIFF
--- a/src/node_osrm.cpp
+++ b/src/node_osrm.cpp
@@ -335,6 +335,9 @@ NAN_METHOD(Engine::match)
     if (obj->Has(NanNew("matching_beta"))) {
         params->matching_beta = obj->Get(NanNew("matching_beta"))->NumberValue();
     }
+    if (obj->Has(NanNew("compression"))) {
+        params->compression = obj->Get(NanNew("compression"))->BooleanValue();
+    }
 
     if (timestamps->IsArray()) {
         Local<Array> timestamps_array = Local<Array>::Cast(timestamps);


### PR DESCRIPTION
`osrm-backend` supports a `compression` parameter for the match method, enabling or disabling polyline compression of returned geometries. This patch adds support for that flag to node-osrm.