### PR TITLE
Remove protbuf dependencies, libosmium has own parser

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -28,8 +28,6 @@ function all_deps() {
     dep boost_libdate_time 1.57.0 &
     dep expat 2.1.0 &
     dep stxxl 1.4.1 &
-    dep osmpbf 1.3.3 &
-    dep protobuf 2.6.1 &
     dep bzip 1.0.6 &
     dep zlib system &
     dep tbb 43_20150316 &


### PR DESCRIPTION
Fixes failing build because of `protobuf`