### PR TITLE
Fix binding.gyp for Build from source

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
       'target_name': '<(module_name)',
       'include_dirs': [
           "<!(node -e \"require('nan')\")",
-          '<!@(pkg-config libosrm --cflags)',
+          '<!@(pkg-config libosrm --variable=includedir)',
           './src/'
       ],
       'libraries': [
@@ -24,7 +24,7 @@
               '-std=c++11'
           ],
           'libraries':[
-              '-Wl,-rpath=<!@(pkg-config libosrm --variable=prefix)/lib',
+              '-Wl,-rpath=<!@(pkg-config libosrm --variable=libdir)',
               '-lboost_program_options',
               '-lboost_regex'
           ]}


### PR DESCRIPTION
Hello,
I've fixed binding.gyp file to be able to build with node-pre-gyp and `--build-from-source` option from local installation of osrm.

Fabien