### PR TITLE
Upgrade to use osrm-backend 4.9.0-rc3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
 env:
   global:
    - JOBS: "3"
-   - OSRM_RELEASE: "v4.8.1"
+   - OSRM_RELEASE: "v4.9.0-rc3"
    - secure: KitzGZjoDblX/3heajcvssGz0JnJ/k02dr2tu03ksUV+6MogC3RSQudqyKY57+f8VyZrcllN/UOlJ0Q/3iG38Oz8DljC+7RZxtkVmE1SFBoOezKCdhcvWM12G3uqPs7hhrRxuUgIh0C//YXEkulUrqa2H1Aj2xeen4E3FAqEoy0=
    - secure: WLGmxl6VTVWhXGm6X83GYNYzPNsvTD+9usJOKM5YBLAdG7cnOBQBNiCCUKc9OZMMZVUr3ec2/iigakH5Y8Yc+U6AlWKzlORyqWLuk4nFuoedu62x6ocQkTkuOc7mHiYhKd21xTGMYauaZRS6kugv4xkpGES2UjI2T8cjZ+LN2jU=
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,8 @@
           './src/'
       ],
       'libraries': [
-        '<!@(pkg-config libosrm --libs)'
+        '<!@(pkg-config libosrm --libs)',
+        '-ltbb'
       ],
       'defines': ['LIBOSRM_GIT_REVISION="<!@(pkg-config libosrm --modversion)"'],
       'conditions': [

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,10 +107,6 @@ function main() {
         git checkout .
         git checkout ${OSRM_RELEASE}
 
-        # workaround https://github.com/Project-OSRM/node-osrm/issues/92
-        perl -i -p -e "s/-fprofile-arcs -ftest-coverage//g;" CMakeLists.txt
-        perl -i -p -e "s/\${CMAKE_CXX_FLAGS} -flto/\${CMAKE_CXX_FLAGS}/g;" CMakeLists.txt
-
         rm -rf build
         mkdir -p build
         cd build

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,7 +10,7 @@ CURRENT_DIR=$(pwd)
 # default to clang
 CXX=${CXX:-clang++}
 TARGET=${TARGET:-Release}
-OSRM_RELEASE=${OSRM_RELEASE:-"v4.8.1"}
+OSRM_RELEASE=${OSRM_RELEASE:-"v4.9.0-rc3"}
 OSRM_REPO=${OSRM_REPO:-"https://github.com/Project-OSRM/osrm-backend.git"}
 
 function all_deps() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,10 +36,6 @@ function all_deps() {
 
 function move_tool() {
     cp ${MASON_HOME}/bin/$1 "${TARGET_DIR}/"
-    if [[ `uname -s` == 'Darwin' ]]; then
-        install_name_tool -change libtbb.dylib @loader_path/libtbb.dylib ${TARGET_DIR}/$1
-        install_name_tool -change libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ${TARGET_DIR}/$1
-    fi
 }
 
 function copy_tbb() {
@@ -70,6 +66,11 @@ function main() {
     export MASON_HOME=$(pwd)/mason_packages/.link
     if [[ ! -d ${MASON_HOME} ]]; then
         all_deps
+    fi
+    # fix install name of tbb
+    if [[ `uname -s` == 'Darwin' ]]; then
+        install_name_tool -id @loader_path/libtbb.dylib ${MASON_HOME}/lib/libtbb.dylib
+        install_name_tool -id @loader_path/libtbb.dylib ${MASON_HOME}/lib/libtbbmalloc.dylib
     fi
     export PATH=${MASON_HOME}/bin:$PATH
     export PKG_CONFIG_PATH=${MASON_HOME}/lib/pkgconfig


### PR DESCRIPTION
- Starts testing against latest osrm-backend tag 
- Fixes #116 

Before merging:

  - Uncomment tests after #122 is fixed 
  - Fix #123
