### PR TITLE
Rm deps dir in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ clean:
 	rm -f ./*tgz
 	rm -rf ./mason_packages
 	rm -rf ./osrm-backend-*
+	rm -rf ./deps
 
 grind:
 	valgrind --leak-check=full node node_modules/.bin/_mocha


### PR DESCRIPTION
Adds `./deps` to `make clean` to purge old osrm-backend versions.
cc @springmeyer 