### PR TITLE
Pass variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,10 +79,8 @@ before_script:
 - ulimit -c unlimited -S
 
 script:
-- source ./osrm-settings.env && make -C ./test/data
-- ./lib/binding/osrm-datastore ./test/data/berlin-latest.osrm
 - RESULT=0
-- npm test || RESULT=$?
+- make test || RESULT=$?
 - for i in $(find ./ -maxdepth 1 -name 'core*' -print); do gdb $(which node) $i -ex "thread apply all bt" -ex "set pagination 0" -batch; done;
 - if [[ ${RESULT} != 0 ]]; then exit $RESULT; fi
 - if [[ ${COVERAGE} == true ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,8 +92,10 @@ before_script:
 - ulimit -c unlimited -S
 
 script:
+- source ./osrm-settings.env && make -C ./test/data
+- ./lib/binding/osrm-datastore ./test/data/berlin-latest.osrm
 - RESULT=0
-- make test || RESULT=$?
+- npm test || RESULT=$?
 - for i in $(find ./ -maxdepth 1 -name 'core*' -print); do gdb $(which node) $i -ex "thread apply all bt" -ex "set pagination 0" -batch; done;
 - if [[ ${RESULT} != 0 ]]; then exit $RESULT; fi
 - if [[ ${COVERAGE} == true ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ matrix:
 env:
   global:
    - JOBS: "3"
-   - OSRM_RELEASE: "develop"
    - secure: KitzGZjoDblX/3heajcvssGz0JnJ/k02dr2tu03ksUV+6MogC3RSQudqyKY57+f8VyZrcllN/UOlJ0Q/3iG38Oz8DljC+7RZxtkVmE1SFBoOezKCdhcvWM12G3uqPs7hhrRxuUgIh0C//YXEkulUrqa2H1Aj2xeen4E3FAqEoy0=
    - secure: WLGmxl6VTVWhXGm6X83GYNYzPNsvTD+9usJOKM5YBLAdG7cnOBQBNiCCUKc9OZMMZVUr3ec2/iigakH5Y8Yc+U6AlWKzlORyqWLuk4nFuoedu62x6ocQkTkuOc7mHiYhKd21xTGMYauaZRS6kugv4xkpGES2UjI2T8cjZ+LN2jU=
 

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,24 @@ pkgconfig:
 	npm install node-pre-gyp
 
 ./build: pkgconfig ./node_modules ./mason_packages
-	export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang=1
+	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \
+	  echo "*** Using osrm installed at `pkg-config libosrm --variable=prefix` ***" && \
+	  ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang=1
 
 debug: pkgconfig ./node_modules ./mason_packages
-	export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && export TARGET=Debug && ./bootstrap.sh && ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1
+	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \
+	  echo "*** Using osrm installed at `pkg-config libosrm --variable=prefix` ***" && \
+	  export TARGET=Debug && ./bootstrap.sh && ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1
 
 coverage: pkgconfig ./node_modules ./mason_packages
-	export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1 --coverage=true
+	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \
+	  echo "*** Using osrm installed at `pkg-config libosrm --variable=prefix` ***" && \
+	  ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1 --coverage=true
 
 verbose: pkgconfig ./node_modules ./mason_packages
-	export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && ./node_modules/.bin/node-pre-gyp configure build --loglevel=verbose --clang=1
+	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \
+	  echo "*** Using osrm installed at `pkg-config libosrm --variable=prefix` ***" && \
+	  ./node_modules/.bin/node-pre-gyp configure build --loglevel=verbose --clang=1
 
 clean:
 	(cd test/data/ && $(MAKE) clean)
@@ -39,9 +47,12 @@ clean:
 grind:
 	valgrind --leak-check=full node node_modules/.bin/_mocha
 
+# Note: this PATH setting is used to allow the localized tools to be used
+# but your locally installed osrm-backend tool, if on PATH should override
 shm: ./test/data/Makefile
-	@PATH="./lib/binding:${PATH}" && $(MAKE) -C ./test/data
-	@PATH="./lib/binding:${PATH}" && osrm-datastore ./test/data/berlin-latest.osrm
+	@PATH="${PATH}:./lib/binding" && echo "*** Using osrm-datastore from `which osrm-datastore` ***"
+	@PATH="${PATH}:./lib/binding" && $(MAKE) -C ./test/data
+	@PATH="${PATH}:./lib/binding" && osrm-datastore ./test/data/berlin-latest.osrm
 
 test: shm
 	npm test

--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,20 @@ pkgconfig:
 ./node_modules: ./node_modules/nan
 	npm install node-pre-gyp
 
-./build: ./osrm-settings.env pkgconfig ./node_modules
-	source ./osrm-settings.env && ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang=1
+./build: pkgconfig ./node_modules
+	./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang=1
 
 debug: pkgconfig ./node_modules ./osrm-settings.env
-	export TARGET=Debug && ./bootstrap.sh && source ./osrm-settings.env && ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1
+	export TARGET=Debug && ./bootstrap.sh && ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1
 
 coverage: pkgconfig ./node_modules ./osrm-settings.env
-	source ./osrm-settings.env && ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1 --coverage=true
+	./node_modules/.bin/node-pre-gyp configure build --debug --clang=1 --coverage=true
 
 verbose: pkgconfig ./node_modules ./osrm-settings.env
-	source ./osrm-settings.env && ./node_modules/.bin/node-pre-gyp configure build --loglevel=verbose --clang=1
+	./node_modules/.bin/node-pre-gyp configure build --loglevel=verbose --clang=1
 
 clean:
-	(source ./osrm-settings.env && cd test/data/ && $(MAKE) clean)
+	(cd test/data/ && $(MAKE) clean)
 	rm -rf ./build
 	rm -rf ./lib/binding/*
 	rm -rf ./node_modules/
@@ -36,16 +36,15 @@ clean:
 	rm -rf ./mason_packages
 	rm -rf ./osrm-backend-*
 	rm -rf ./deps
-	rm -f ./osrm-settings.env
 
 grind:
 	valgrind --leak-check=full node node_modules/.bin/_mocha
 
-shm: ./osrm-settings.env ./test/data/Makefile
-	source ./osrm-settings.env && $(MAKE) -C ./test/data
-	source ./osrm-settings.env && osrm-datastore ./test/data/berlin-latest.osrm
+shm: ./test/data/Makefile
+	PATH="./lib/binding:${PATH}" && $(MAKE) -C ./test/data
+	PATH="./lib/binding:${PATH}" && osrm-datastore ./test/data/berlin-latest.osrm
 
-test: ./osrm-settings.env shm
+test: shm
 	npm test
 
 .PHONY: test clean build shm

--- a/README.md
+++ b/README.md
@@ -125,9 +125,12 @@ osrm.route(query, function (err, result) {
 
 You can build from source by using [mason](https://github.com/mapbox/mason).
 Just go to your node-osrm folder and run:
+
 ```
-. ./bootstrap.sh
+./bootstrap.sh
+source ./osrm-settings.env
 ```
+
 This will download and build the current version of osrm-backend and set all needed variables.
 After having run `bootstrap.sh` successfully, run:
 ```

--- a/README.md
+++ b/README.md
@@ -127,26 +127,36 @@ You can build from source by using [mason](https://github.com/mapbox/mason).
 Just go to your node-osrm folder and run:
 
 ```
-./bootstrap.sh
-source ./osrm-settings.env
+make
 ```
 
 This will download and build the current version of osrm-backend and set all needed variables.
-After having run `bootstrap.sh` successfully, run:
-```
-npm install --build-from-source
-```
 
-If you wish to use another version of osrm-backend, change `bootstrap.sh` and replace the `OSRM-RELEASE` with the commit hash of the version you would like to use:
+Then you can test like
+
 ```
-OSRM_RELEASE=${OSRM_RELEASE:-" ENTER_COMMIT_HASH_HERE "}
+make test
 ```
 
-## Using a local OSRM
+To rebuild node-osrm after any source code changes to `src/node_osrm.cpp` simply type again:
 
-If you do not wish to use mason and build from source completely you will need:
+```
+make
+```
 
- - OSRM >= 0.4.2
+If you wish to have a different version of osrm-backend build on the fly, change the `osrm_release` variable in `package.json` and rebuild:
+
+```
+make clean
+make && make test
+```
+
+## Using an existing local osrm-backend
+
+If you do not wish to build node-osrm against an existing osrm-backend that you have on your system you will need:
+
+ - OSRM develop branch cloned, built from source, and installed
+ - The test data initialized: `make -C test/data` inside the `osrm-backend` directory
 
 See [Project-OSRM wiki](https://github.com/Project-OSRM/osrm-backend/wiki/Building%20OSRM) for details.
 
@@ -161,6 +171,29 @@ Now you can build `node-osrm`:
     git clone https://github.com/Project-OSRM/node-osrm.git
     cd node-osrm
     npm install --build-from-source
+
+To run the tests against your local osrm-backend's data you will need to
+set the `OSRM_DATA_PATH` variable:
+
+    export OSRM_DATA_PATH=/path/to/osrm-backend/test/data
+
+Then you can run `npm test`.
+
+To recap, here is a full example of building against an osrm-backend that is cloned beside node-osrm but installed into a custom location:
+
+```
+export PATH=/opt/osrm/bin:${PATH}
+export PKG_CONFIG_PATH=/opt/osrm/lib/pkgconfig
+pkg-config libosrm --variable=prefix
+# if boost headers are in a custom location give a hint about that
+# here we assume the are in `/opt/boost`
+export CXXFLAGS="-I/opt/boost/include"
+npm install --build-from-source
+# build the osrm-backend test data
+make -C ../osrm-backend/test/data
+export OSRM_DATA_PATH=../osrm-backend/test/data
+npm test
+```
 
 # Developing
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,18 +107,6 @@ function build_osrm() {
     popd
 }
 
-# NOTE: the `osrm-settings.env` is used by test/run (which is run by `make test`)
-function setup_runtime_settings() {
-    echo "export OSRM_RELEASE=${OSRM_RELEASE}" > osrm-settings.env
-    echo "export TOOL_ROOT=${TOOL_ROOT}" >> osrm-settings.env
-    echo "export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}" >> osrm-settings.env
-    echo "export C_INCLUDE_PATH=${C_INCLUDE_PATH}" >> osrm-settings.env
-    echo "export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}" >> osrm-settings.env
-    echo "export LIBRARY_PATH=${LIBRARY_PATH}" >> osrm-settings.env
-    echo "export PATH=${TOOL_ROOT}:"'$PATH' >> osrm-settings.env
-    echo "generated osrm-settings.env"
-}
-
 function main() {
     if [[ ! -d ./.mason ]]; then
         git clone --depth 1 https://github.com/mapbox/mason.git ./.mason
@@ -159,7 +147,6 @@ function main() {
 
     localize
 
-    setup_runtime_settings
     if [[ ${BUILD_TYPE} == 'Debug' ]]; then
         echo "success: now run 'npm install --build-from-source --debug'"
     else

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,8 +19,6 @@ echo
 echo "*******************"
 echo -e "OSRM_RELEASE set to:   \033[1m\033[36m ${OSRM_RELEASE}\033[0m"
 echo -e "BUILD_TYPE set to:     \033[1m\033[36m ${BUILD_TYPE}\033[0m"
-echo -e "TOOL_ROOT set to:      \033[1m\033[36m ${TOOL_ROOT}\033[0m"
-echo -e "OSRM_DIR set to:       \033[1m\033[36m ${OSRM_DIR}\033[0m"
 echo "*******************"
 echo
 echo

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,18 +7,18 @@ function dep() {
     ./.mason/mason link $1 $2
 }
 
-# default to clang
+# Set 'osrm_release' to a branch, tag, or gitsha in package.json
+export OSRM_RELEASE=$(node -e "console.log(require('./package.json').osrm_release)")
 export CXX=${CXX:-clang++}
-export TARGET=${TARGET:-Release}
-export OSRM_RELEASE=${OSRM_RELEASE:-"develop"}
+export BUILD_TYPE=${BUILD_TYPE:-Release}
 export TOOL_ROOT=${TOOL_ROOT:-$(pwd)/lib/binding}
 export OSRM_REPO=${OSRM_REPO:-"https://github.com/Project-OSRM/osrm-backend.git"}
-export OSRM_DIR=$(pwd)/deps/osrm-backend-${TARGET}
+export OSRM_DIR=$(pwd)/deps/osrm-backend-${BUILD_TYPE}
 
 echo
 echo "*******************"
 echo -e "OSRM_RELEASE set to:   \033[1m\033[36m ${OSRM_RELEASE}\033[0m"
-echo -e "TARGET set to:         \033[1m\033[36m ${TARGET}\033[0m"
+echo -e "BUILD_TYPE set to:     \033[1m\033[36m ${BUILD_TYPE}\033[0m"
 echo -e "TOOL_ROOT set to:      \033[1m\033[36m ${TOOL_ROOT}\033[0m"
 echo -e "OSRM_DIR set to:       \033[1m\033[36m ${OSRM_DIR}\033[0m"
 echo "*******************"
@@ -99,7 +99,7 @@ function build_osrm() {
       -DTBB_INSTALL_DIR=${MASON_HOME} \
       -DCMAKE_INCLUDE_PATH=${MASON_HOME}/include \
       -DCMAKE_LIBRARY_PATH=${MASON_HOME}/lib \
-      -DCMAKE_BUILD_TYPE=${TARGET} \
+      -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DCMAKE_EXE_LINKER_FLAGS="${LINK_FLAGS}"
     make -j${JOBS} && make install
     popd
@@ -160,7 +160,7 @@ function main() {
     localize
 
     setup_runtime_settings
-    if [[ ${TARGET} == 'Debug' ]]; then
+    if [[ ${BUILD_TYPE} == 'Debug' ]]; then
         echo "success: now run 'npm install --build-from-source --debug'"
     else
         echo "success: now run 'npm install --build-from-source'"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
   "version": "4.9.0-develop.0",
+  "osrm_release" : "develop",
   "main": "./lib/osrm.js",
   "license": "BSD",
   "bugs": {

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -24,7 +24,9 @@ car.lua: lib/access.lua
 	wget $(CAR_PROFILE_URL) -O car.lua
 
 clean:
-	rm berlin-latest.*
+	rm -f ./berlin-latest.*
+	rm -f ./car.lua
+	rm -rf ./lib
 
 berlin-latest.osm.pbf:
 	wget $(BERLIN_URL) -O berlin-latest.osm.pbf

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -1,18 +1,15 @@
 
+OSRM_RELEASE := $(shell node -e "console.log(require('../../package.json').osrm_release)")
 
 ifeq ($(OSRM_RELEASE),)
-$(error OSRM_RELEASE variable is not set)
-endif
-
-ifeq ($(TOOL_ROOT),)
-$(error TOOL_ROOT variable is not set)
+$(error OSRM_RELEASE variable was not correct set)
 endif
 
 CAR_PROFILE_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/car.lua
 PROFILE_LIB_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/lib/access.lua
 BERLIN_URL:=https://s3.amazonaws.com/mapbox/node-osrm/testing/berlin-latest.osm.pbf
-OSRM_EXTRACT:=$(TOOL_ROOT)/osrm-extract
-OSRM_PREPARE:=$(TOOL_ROOT)/osrm-prepare
+OSRM_EXTRACT:=../../lib/binding/osrm-extract
+OSRM_PREPARE:=../../lib/binding/osrm-prepare
 
 all: berlin-latest.osrm.hsgr
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 var OSRM = require('../');
 var test = require('tape');
-var berlin_path = "test/data/berlin-latest.osrm";
+var berlin_path = require('./osrm-data-path').data_path;
 
 test('constructor: throws if new keyword is not used', function(assert) {
     assert.plan(1);

--- a/test/match.js
+++ b/test/match.js
@@ -1,6 +1,6 @@
 var OSRM = require('../');
 var test = require('tape');
-var berlin_path = "test/data/berlin-latest.osrm";
+var berlin_path = require('./osrm-data-path').data_path;
 
 test('match: match in Berlin', function(assert) {
     assert.plan(2);

--- a/test/nearest.js
+++ b/test/nearest.js
@@ -1,6 +1,6 @@
 var OSRM = require('../');
 var test = require('tape');
-var berlin_path = "test/data/berlin-latest.osrm";
+var berlin_path = require('./osrm-data-path').data_path;
 
 test('nearest', function(assert) {
     assert.plan(3);

--- a/test/osrm-data-path.js
+++ b/test/osrm-data-path.js
@@ -1,0 +1,8 @@
+var path = require('path');
+
+if (process.env.OSRM_DATA_PATH !== undefined) {
+    exports.data_path = path.resolve(process.env.OSRM_DATA_PATH);
+    console.log('Setting custom data path to ' + exports.data_path);
+} else {
+    exports.data_path = path.resolve("../../test/data/berlin-latest.osrm");    
+}

--- a/test/osrm-data-path.js
+++ b/test/osrm-data-path.js
@@ -1,7 +1,7 @@
 var path = require('path');
 
 if (process.env.OSRM_DATA_PATH !== undefined) {
-    exports.data_path = path.resolve(process.env.OSRM_DATA_PATH);
+    exports.data_path = path.join(path.resolve(process.env.OSRM_DATA_PATH),"berlin-latest.osrm");
     console.log('Setting custom data path to ' + exports.data_path);
 } else {
     exports.data_path = path.resolve("../../test/data/berlin-latest.osrm");    

--- a/test/osrm-data-path.js
+++ b/test/osrm-data-path.js
@@ -4,5 +4,5 @@ if (process.env.OSRM_DATA_PATH !== undefined) {
     exports.data_path = path.join(path.resolve(process.env.OSRM_DATA_PATH),"berlin-latest.osrm");
     console.log('Setting custom data path to ' + exports.data_path);
 } else {
-    exports.data_path = path.resolve("../../test/data/berlin-latest.osrm");    
+    exports.data_path = path.resolve(path.join(__dirname,"../test/data/berlin-latest.osrm"));
 }

--- a/test/route.js
+++ b/test/route.js
@@ -1,6 +1,6 @@
 var OSRM = require('../');
 var test = require('tape');
-var berlin_path = "test/data/berlin-latest.osrm";
+var berlin_path = require('./osrm-data-path').data_path;
 
 test('route: routes Berlin', function(assert) {
     assert.plan(2);

--- a/test/table.js
+++ b/test/table.js
@@ -1,6 +1,6 @@
 var OSRM = require('../');
 var test = require('tape');
-var berlin_path = "test/data/berlin-latest.osrm";
+var berlin_path = require('./osrm-data-path').data_path;
 
 test('table: distance table in Berlin', function(assert) {
     assert.plan(9);

--- a/test/trip.js
+++ b/test/trip.js
@@ -1,6 +1,6 @@
 var OSRM = require('../');
 var test = require('tape');
-var berlin_path = "test/data/berlin-latest.osrm";
+var berlin_path = require('./osrm-data-path').data_path;
 
 test('trip: trip in Berlin', function(assert) {
     assert.plan(2);


### PR DESCRIPTION
Currently to install node-osrm from binaries you run: `npm install`.

To install from source you type `make`. And to run the tests after a source build: `make test`.

However when doing development against custom branches of OSRM_BACKEND there were a variety of easy pitfalls.

This branch makes it easier, and documented, how you should:

  - Build against a custom OSRM branch, tag, or gitsha using mason + an automated source build of osrm-backend (done via the `./bootstrap.sh` script)
  - Build against a local osrm-backend clone that you've been doing development in

Both these methods are documented in the readme in this pull.

