### PR TITLE
Remove travis branch restriction.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,6 @@ git:
 notifications:
   email: false
 
-branches:
-  only:
-    - master
-    - develop
-
-#cache:
-#  directories:
-#    - node_modules
-#    - deps
-
 addons:
   apt:
     sources:


### PR DESCRIPTION
During development it's helpful to have travis build all branches.