### PR TITLE
[Travis] Only test/produce binaries for v0.10 and v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,7 @@ matrix:
      # Linux
      - os: linux
        compiler: gcc
-       env: NODE_VERSION="5" TARGET=Release
-     - os: linux
-       compiler: gcc
        env: NODE_VERSION="4" TARGET=Release
-     - os: linux
-       compiler: gcc
-       env: NODE_VERSION="0.12" TARGET=Release
      - os: linux
        compiler: gcc
        env: NODE_VERSION="0.10" TARGET=Release
@@ -39,13 +33,7 @@ matrix:
      # OS X
      - os: osx
        compiler: clang
-       env: NODE_VERSION="5" TARGET=Release
-     - os: osx
-       compiler: clang
        env: NODE_VERSION="4" TARGET=Release
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="0.12" TARGET=Release
      - os: osx
        compiler: clang
        env: NODE_VERSION="0.10" TARGET=Release


### PR DESCRIPTION
Now that Node.js is stabilized to the LTS concept I think we should only target node v4.x (instead of the old v0.12 that very few updated to and the v5 that is the unstable series). And for a while longer we should still support node v0.10.x.

So, this moves to only testing and building against v0.10.x and v4.x.

The `Project-OSRM` organization on travis only has 5 concurrent builds (like all open source orgs) so this reduces a single node-osrm commit to only triggering 3 jobs on Linux. This should allow for multiple node-osrm commits to different branches to run (almost) in parallel.