### PR TITLE
Make it easier to build against custom osrm-backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ stxxl.log
 *.sublime-*
 mason_packages
 npm-debug.log
+test/data/car.lua
+test/data/lib/access.lua

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
        env: NODE_VERSION="0.10" TARGET=Release
      - os: linux
        compiler: gcc
-       env: NODE_VERSION="0.10" TARGET=Debug NPM_FLAGS="--debug"
+       env: NODE_VERSION="0.10" TARGET=Debug
      # OS X
      - os: osx
        compiler: clang
@@ -40,12 +40,11 @@ matrix:
      # Coverage
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10" COVERAGE=true TARGET=Debug NPM_FLAGS="--debug"
+       env: NODE_VERSION="0.10" COVERAGE=true TARGET=Debug
 
 env:
   global:
    - JOBS: "3"
-   - OSRM_RELEASE: "develop"
    - secure: KitzGZjoDblX/3heajcvssGz0JnJ/k02dr2tu03ksUV+6MogC3RSQudqyKY57+f8VyZrcllN/UOlJ0Q/3iG38Oz8DljC+7RZxtkVmE1SFBoOezKCdhcvWM12G3uqPs7hhrRxuUgIh0C//YXEkulUrqa2H1Aj2xeen4E3FAqEoy0=
    - secure: WLGmxl6VTVWhXGm6X83GYNYzPNsvTD+9usJOKM5YBLAdG7cnOBQBNiCCUKc9OZMMZVUr3ec2/iigakH5Y8Yc+U6AlWKzlORyqWLuk4nFuoedu62x6ocQkTkuOc7mHiYhKd21xTGMYauaZRS6kugv4xkpGES2UjI2T8cjZ+LN2jU=
 
@@ -68,13 +67,12 @@ before_install:
 - source ./scripts/install_node.sh ${NODE_VERSION}
 
 install:
-- source ./bootstrap.sh
 - if [[ ${COVERAGE} == true ]]; then
     PYTHONUSERBASE=$(pwd)/mason_packages/.link pip install --user cpp-coveralls;
     export LDFLAGS="--coverage";
     export CXXFLAGS="--coverage";
   fi;
-- npm install --build-from-source ${NPM_FLAGS} --clang=1;
+- if [[ ${TARGET} == 'Release' ]]; then make; else make debug; fi
 
 before_script:
 - ulimit -c unlimited -S

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,24 +23,27 @@ matrix:
      # Linux
      - os: linux
        compiler: gcc
-       env: NODE_VERSION="4" TARGET=Release
+       env: NODE="4" TARGET=Release PUBLISHABLE=true
      - os: linux
        compiler: gcc
-       env: NODE_VERSION="0.10" TARGET=Release
+       env: NODE="0.10" TARGET=Release PUBLISHABLE=true
      - os: linux
        compiler: gcc
-       env: NODE_VERSION="0.10" TARGET=Debug
+       env: NODE="0.10" TARGET=Debug PUBLISHABLE=true
      # OS X
      - os: osx
        compiler: clang
-       env: NODE_VERSION="4" TARGET=Release
+       env: NODE="4" TARGET=Release PUBLISHABLE=true
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10" TARGET=Release
+       env: NODE="0.10" TARGET=Release PUBLISHABLE=true
+     - os: osx
+       compiler: clang
+       env: NODE="0.10" TARGET=Debug PUBLISHABLE=true
      # Coverage
      - os: osx
        compiler: clang
-       env: NODE_VERSION="0.10" COVERAGE=true TARGET=Debug
+       env: NODE="0.10" COVERAGE=true TARGET=Debug PUBLISHABLE=false
 
 env:
   global:
@@ -64,7 +67,7 @@ before_install:
     brew install md5sha1sum;
   fi
 # Mac OS X does not have nvm installed
-- source ./scripts/install_node.sh ${NODE_VERSION}
+- source ./scripts/install_node.sh ${NODE}
 
 install:
 - if [[ ${COVERAGE} == true ]]; then
@@ -84,6 +87,7 @@ script:
 - if [[ ${RESULT} != 0 ]]; then exit $RESULT; fi
 - if [[ ${COVERAGE} == true ]]; then
     ./mason_packages/.link/bin/cpp-coveralls --exclude node_modules --exclude mason_packages --exclude tests --build-root build --gcov-options '\-lp' --exclude doc --exclude build/Release/obj/gen;
-  else
+  fi;
+- if [[ ${PUBLISHABLE} == true ]]; then
     ./scripts/publish.sh;
   fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_install:
     sudo sysctl -w kern.sysv.shmall=1048576
     sudo sysctl -w kern.sysv.shmseg=128
     export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python/site-packages;
-    brew update && brew install md5sha1sum;
+    brew install md5sha1sum;
   fi
 # Mac OS X does not have nvm installed
 - source ./scripts/install_node.sh ${NODE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 debug: ./node_modules ./mason_packages
 	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \
 	  echo "*** Using osrm installed at `pkg-config libosrm --variable=prefix` ***" && \
-	  export TARGET=Debug && ./bootstrap.sh && ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1
+	  export BUILD_TYPE=Debug && ./bootstrap.sh && ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1
 
 verbose: ./node_modules ./mason_packages
 	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \

--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ The `node-osrm` module consumes data processed by OSRM core.
 This repository contains a Makefile that does this automatically:
 
 - Downloads an OSM extract
-- Runs `osrm-extract` and `osrm-prepare`
-- Has a OSRM config (ini) file that references the prepared data
+- Runs osrm tools to prepare data
 
 Just run:
 
-    make berlin-latest.osrm.hsgr
+    make test
 
 Once that is done then you can calculate routes in Javascript like:
 

--- a/README.md
+++ b/README.md
@@ -125,25 +125,38 @@ osrm.route(query, function (err, result) {
 
 You can build from source by using [mason](https://github.com/mapbox/mason).
 Just go to your node-osrm folder and run:
+
 ```
-. ./bootstrap.sh
+make
 ```
+
 This will download and build the current version of osrm-backend and set all needed variables.
-After having run `bootstrap.sh` successfully, run:
-```
-npm install --build-from-source
-```
 
-If you wish to use another version of osrm-backend, change `bootstrap.sh` and replace the `OSRM-RELEASE` with the commit hash of the version you would like to use:
+Then you can test like
+
 ```
-OSRM_RELEASE=${OSRM_RELEASE:-" ENTER_COMMIT_HASH_HERE "}
+make test
 ```
 
-## Using a local OSRM
+To rebuild node-osrm after any source code changes to `src/node_osrm.cpp` simply type again:
 
-If you do not wish to use mason and build from source completely you will need:
+```
+make
+```
 
- - OSRM >= 0.4.2
+If you wish to have a different version of osrm-backend build on the fly, change the `osrm_release` variable in `package.json` and rebuild:
+
+```
+make clean
+make && make test
+```
+
+## Using an existing local osrm-backend
+
+If you do not wish to build node-osrm against an existing osrm-backend that you have on your system you will need:
+
+ - OSRM develop branch cloned, built from source, and installed
+ - The test data initialized: `make -C test/data` inside the `osrm-backend` directory
 
 See [Project-OSRM wiki](https://github.com/Project-OSRM/osrm-backend/wiki/Building%20OSRM) for details.
 
@@ -158,6 +171,29 @@ Now you can build `node-osrm`:
     git clone https://github.com/Project-OSRM/node-osrm.git
     cd node-osrm
     npm install --build-from-source
+
+To run the tests against your local osrm-backend's data you will need to
+set the `OSRM_DATA_PATH` variable:
+
+    export OSRM_DATA_PATH=/path/to/osrm-backend/test/data
+
+Then you can run `npm test`.
+
+To recap, here is a full example of building against an osrm-backend that is cloned beside node-osrm but installed into a custom location:
+
+```
+export PATH=/opt/osrm/bin:${PATH}
+export PKG_CONFIG_PATH=/opt/osrm/lib/pkgconfig
+pkg-config libosrm --variable=prefix
+# if boost headers are in a custom location give a hint about that
+# here we assume the are in `/opt/boost`
+export CXXFLAGS="-I/opt/boost/include"
+npm install --build-from-source
+# build the osrm-backend test data
+make -C ../osrm-backend/test/data
+export OSRM_DATA_PATH=../osrm-backend/test/data
+npm test
+```
 
 # Developing
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -51,8 +51,8 @@ function all_deps() {
     wait
 }
 
-function move_tool() {
-    cp ${MASON_HOME}/bin/$1 "${TARGET_DIR}/"
+function move_tools() {
+    cp -r ${MASON_HOME}/bin/osrm-* "${TARGET_DIR}/"
 }
 
 function copy_tbb() {
@@ -70,9 +70,7 @@ function localize() {
     mkdir -p ${TARGET_DIR}
     copy_tbb
     cp ${MASON_HOME}/bin/lua ${TARGET_DIR}
-    move_tool osrm-extract
-    move_tool osrm-datastore
-    move_tool osrm-prepare
+    move_tools
 }
 
 function build_osrm() {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -111,9 +111,7 @@ function main() {
     fi
     export MASON_DIR=$(pwd)/.mason
     export MASON_HOME=$(pwd)/mason_packages/.link
-    if [[ ! -d ${MASON_HOME} ]]; then
-        all_deps
-    fi
+    all_deps
     # fix install name of tbb
     if [[ `uname -s` == 'Darwin' ]]; then
         install_name_tool -id @loader_path/libtbb.dylib ${MASON_HOME}/lib/libtbb.dylib

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,14 +7,28 @@ function dep() {
     ./.mason/mason link $1 $2
 }
 
-CURRENT_DIR=$(pwd)
+# Set 'osrm_release' to a branch, tag, or gitsha in package.json
+export OSRM_RELEASE=$(node -e "console.log(require('./package.json').osrm_release)")
+export CXX=${CXX:-clang++}
+export BUILD_TYPE=${BUILD_TYPE:-Release}
+export TARGET_DIR=${TARGET_DIR:-$(pwd)/lib/binding}
+export OSRM_REPO=${OSRM_REPO:-"https://github.com/Project-OSRM/osrm-backend.git"}
+export OSRM_DIR=$(pwd)/deps/osrm-backend-${BUILD_TYPE}
 
-# default to clang
-CXX=${CXX:-clang++}
-TARGET=${TARGET:-Release}
-OSRM_RELEASE=${OSRM_RELEASE:-"develop"}
-OSRM_REPO=${OSRM_REPO:-"https://github.com/Project-OSRM/osrm-backend.git"}
-OSRM_DIR=deps/osrm-backend-${TARGET}
+echo
+echo "*******************"
+echo -e "OSRM_RELEASE set to:   \033[1m\033[36m ${OSRM_RELEASE}\033[0m"
+echo -e "BUILD_TYPE set to:     \033[1m\033[36m ${BUILD_TYPE}\033[0m"
+echo "*******************"
+echo
+echo
+
+if [[ `which pkg-config` ]]; then
+    echo "Success: Found pkg-config";
+else
+    echo "echo you need pkg-config installed";
+    exit 1;
+fi;
 
 function all_deps() {
     dep cmake 3.2.2 &
@@ -73,21 +87,17 @@ function build_osrm() {
         git fetch
     fi
 
-
-    echo "Using OSRM ${OSRM_RELEASE}"
-    echo "Using OSRM ${OSRM_REPO}"
     git checkout ${OSRM_RELEASE}
-    git reset --hard origin/${OSRM_RELEASE}
 
     mkdir -p build
     pushd build
-    cmake ../ -DCMAKE_INSTALL_PREFIX=${MASON_HOME} \
+    ../../../mason_packages/.link/bin/cmake ../ -DCMAKE_INSTALL_PREFIX=${MASON_HOME} \
       -DCMAKE_CXX_COMPILER="$CXX" \
       -DBoost_NO_SYSTEM_PATHS=ON \
       -DTBB_INSTALL_DIR=${MASON_HOME} \
       -DCMAKE_INCLUDE_PATH=${MASON_HOME}/include \
       -DCMAKE_LIBRARY_PATH=${MASON_HOME}/lib \
-      -DCMAKE_BUILD_TYPE=${TARGET} \
+      -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DCMAKE_EXE_LINKER_FLAGS="${LINK_FLAGS}"
     make -j${JOBS} && make install
     popd
@@ -109,7 +119,6 @@ function main() {
         install_name_tool -id @loader_path/libtbb.dylib ${MASON_HOME}/lib/libtbb.dylib
         install_name_tool -id @loader_path/libtbb.dylib ${MASON_HOME}/lib/libtbbmalloc.dylib
     fi
-    export PATH=${MASON_HOME}/bin:$PATH
     export PKG_CONFIG_PATH=${MASON_HOME}/lib/pkgconfig
 
     # environment variables to tell the compiler and linker
@@ -122,12 +131,6 @@ function main() {
     export CPLUS_INCLUDE_PATH="${MASON_HOME}/include"
     export LIBRARY_PATH="${MASON_HOME}/lib"
 
-    if [[ ! -d ./node_modules/node-pre-gyp ]]; then
-        npm install node-pre-gyp
-    fi
-
-    export TARGET_DIR=$(./node_modules/.bin/node-pre-gyp reveal module_path --silent)
-
     LINK_FLAGS=""
     if [[ $(uname -s) == 'Linux' ]]; then
         LINK_FLAGS="${LINK_FLAGS} "'-Wl,-z,origin -Wl,-rpath=\$ORIGIN'
@@ -136,10 +139,6 @@ function main() {
     build_osrm
 
     localize
-
-    #if [[ `uname -s` == 'Darwin' ]]; then otool -L ./lib/binding/* || true; fi
-    #if [[ `uname -s` == 'Linux' ]]; then readelf -d ./lib/binding/* || true; fi
-    echo "success: now run 'npm install --build-from-source'"
 }
 
 main

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
   "version": "4.9.0-develop.0",
+  "osrm_release" : "develop",
   "main": "./lib/osrm.js",
   "license": "BSD",
   "bugs": {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-./node_modules/.bin/node-pre-gyp package ${NPM_FLAGS}
+./node_modules/.bin/node-pre-gyp package
 
 COMMIT_MESSAGE=$(git log --format=%B --no-merges | head -n 1 | tr -d '\n')
 echo "Commit message: ${COMMIT_MESSAGE}"
 
 if [[ ${COMMIT_MESSAGE} =~ "[publish binary]" ]]; then
     echo "Publishing"
-    ./node_modules/.bin/node-pre-gyp publish ${NPM_FLAGS}
+    ./node_modules/.bin/node-pre-gyp publish
 elif [[ ${COMMIT_MESSAGE} =~ "[republish binary]" ]]; then
     echo "Re-Publishing"
-    ./node_modules/.bin/node-pre-gyp unpublish publish ${NPM_FLAGS}
+    ./node_modules/.bin/node-pre-gyp unpublish publish
 else
     echo "Skipping publishing"
 fi;

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -8,8 +8,6 @@ endif
 CAR_PROFILE_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/car.lua
 PROFILE_LIB_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/lib/access.lua
 BERLIN_URL:=https://s3.amazonaws.com/mapbox/node-osrm/testing/berlin-latest.osm.pbf
-OSRM_EXTRACT:=../../lib/binding/osrm-extract
-OSRM_PREPARE:=../../lib/binding/osrm-prepare
 
 all: berlin-latest.osrm.hsgr
 
@@ -31,12 +29,14 @@ berlin-latest.osm.pbf:
 berlin-latest.osrm: berlin-latest.osm.pbf car.lua $(OSRM_EXTRACT)
 	@echo "Verifiyng data file integrity..."
 	md5sum -c data.md5sum
+	@PATH="${PATH}:../../lib/binding" && echo "*** Using osrm-extract from `which osrm-extract` ***"
 	@echo "Running osrm-extract..."
-	$(OSRM_EXTRACT) berlin-latest.osm.pbf -p car.lua
+	@PATH="${PATH}:../../lib/binding" && osrm-extract berlin-latest.osm.pbf -p car.lua
 
-berlin-latest.osrm.hsgr: berlin-latest.osrm car.lua $(OSRM_PREPARE)
-	@echo "Running osrm-prepare..."
-	$(OSRM_PREPARE) berlin-latest.osrm -p car.lua
+berlin-latest.osrm.hsgr: berlin-latest.osrm car.lua $(OSRM_CONTRACT)
+	@PATH="${PATH}:../../lib/binding" && echo "*** Using osrm-contract from `which osrm-contract` ***"
+	@echo "Running osrm-contract..."
+	@PATH="${PATH}:../../lib/binding" && osrm-contract berlin-latest.osrm
 
 checksum:
 	md5sum lib/access.lua car.lua berlin-latest.osm.pbf > data.md5sum

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -1,18 +1,15 @@
 
+OSRM_RELEASE := $(shell node -e "console.log(require('../../package.json').osrm_release)")
 
 ifeq ($(OSRM_RELEASE),)
-$(error OSRM_RELEASE variable is not set)
-endif
-
-ifeq ($(TOOL_ROOT),)
-$(error TOOL_ROOT variable is not set)
+$(error OSRM_RELEASE variable was not correct set)
 endif
 
 CAR_PROFILE_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/car.lua
 PROFILE_LIB_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/lib/access.lua
 BERLIN_URL:=https://s3.amazonaws.com/mapbox/node-osrm/testing/berlin-latest.osm.pbf
-OSRM_EXTRACT:=$(TOOL_ROOT)/osrm-extract
-OSRM_PREPARE:=$(TOOL_ROOT)/osrm-prepare
+OSRM_EXTRACT:=../../lib/binding/osrm-extract
+OSRM_PREPARE:=../../lib/binding/osrm-prepare
 
 all: berlin-latest.osrm.hsgr
 


### PR DESCRIPTION
### What Changed

 - centralizes osrm-backend version variable in package.json
 - documents how to build against:
   - a custom osrm-backend version via mason (for portable binaries)
   - or an existing local osrm-backend clone that has already been installed (to iterate fast)
 
**So, no longer do you change the `OSRM_RELEASE` variable in the .travis.yml. Now, instead you change the `osrm_release` variable inside of the `package.json`.**

The idea here is to:

   - Have the `osrm_release` variable just in one place (./bootstrap.sh now pulls from package.json)
   - Avoid using ENV variables and bash `source` which is easy to make mistakes with
   - Make it easier in branch diffs to see the relationship of `osrm-backend` version and `node-osrm` by storing their versions in the same spot.

### GOCHAS

 - If you have the osrm-backend tools on your PATH, they will be used instead of the ones built locally. So, if you are just doing node-osrm development make sure to clean up any stale osrm-backend installs you might have.

### Background

Currently to install node-osrm from binaries you run: `npm install`.

To install from source you type `make`. And to run the tests after a source build: `make test`.

These things will stay the same and they default to building against the osrm-backend `develop` branch.

However when doing development against custom branches of OSRM_BACKEND there were a variety of easy pitfalls.

This branch makes it easier, and documented, how you should:

 - Build against a custom OSRM branch, tag, or gitsha using mason + an automated source build of osrm-backend (done via the ./bootstrap.sh script)
 - Build against a local osrm-backend clone that you've been doing development in

Both these methods are documented in the readme in this pull.