### PR TITLE
[travis] speed up linux builds with clang-3.7+ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
-language: cpp
+language: generic
 
 git:
   depth: 10
+
+cache:
+  directories:
+  - $HOME/.ccache
 
 notifications:
   email: false
@@ -10,9 +14,10 @@ addons:
   apt:
     sources:
      - ubuntu-toolchain-r-test
+     - llvm-toolchain-precise-3.7
     packages:
      - coreutils
-     - g++-4.8
+     - clang-3.7
      - gdb
 
 # TODO: no core files on sudo:false machines until https://github.com/travis-ci/travis-ci/issues/3754 is resolved
@@ -22,13 +27,13 @@ matrix:
   include:
      # Linux
      - os: linux
-       compiler: gcc
+       compiler: ": clang-release-node-v4"
        env: NODE="4" TARGET=Release PUBLISHABLE=true
      - os: linux
-       compiler: gcc
+       compiler: ": clang-release-node-v0.10"
        env: NODE="0.10" TARGET=Release PUBLISHABLE=true
      - os: linux
-       compiler: gcc
+       compiler: ": clang-debug-node-v0.10"
        env: NODE="0.10" TARGET=Debug PUBLISHABLE=true
      # OS X
      - os: osx
@@ -47,7 +52,9 @@ matrix:
 
 env:
   global:
-   - JOBS: "3"
+   - CCACHE_TEMPDIR=/tmp/.ccache-temp
+   - CCACHE_COMPRESS=1
+   - JOBS: "8"
    - secure: KitzGZjoDblX/3heajcvssGz0JnJ/k02dr2tu03ksUV+6MogC3RSQudqyKY57+f8VyZrcllN/UOlJ0Q/3iG38Oz8DljC+7RZxtkVmE1SFBoOezKCdhcvWM12G3uqPs7hhrRxuUgIh0C//YXEkulUrqa2H1Aj2xeen4E3FAqEoy0=
    - secure: WLGmxl6VTVWhXGm6X83GYNYzPNsvTD+9usJOKM5YBLAdG7cnOBQBNiCCUKc9OZMMZVUr3ec2/iigakH5Y8Yc+U6AlWKzlORyqWLuk4nFuoedu62x6ocQkTkuOc7mHiYhKd21xTGMYauaZRS6kugv4xkpGES2UjI2T8cjZ+LN2jU=
 
@@ -56,8 +63,8 @@ before_install:
 - export COVERAGE=${COVERAGE:-false}
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-    export CXX="g++-4.8";
-    export CC="gcc-4.8";
+    export CXX="clang++-3.7";
+    export CC="clang-3.7";
     export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python2.7/site-packages;
   elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     sudo sysctl -w kern.sysv.shmmax=4294967296
@@ -65,6 +72,10 @@ before_install:
     sudo sysctl -w kern.sysv.shmseg=128
     export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python/site-packages;
     brew install md5sha1sum;
+    # osrm-backend picks up ccache automatically
+    # since osx does not support caching we want to avoid
+    # since since it will just slow down builds
+    brew rm ccache || true;
   fi
 # Mac OS X does not have nvm installed
 - source ./scripts/install_node.sh ${NODE}
@@ -76,6 +87,7 @@ install:
     export CXXFLAGS="--coverage";
   fi;
 - if [[ ${TARGET} == 'Release' ]]; then make; else make debug; fi
+- if [[ $(uname -s) == 'Linux' ]]; then du $HOME/.ccache -h --max-depth=1 | sort -hr; fi;
 
 before_script:
 - ulimit -c unlimited -S

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -104,6 +104,14 @@ function build_osrm() {
 
     mkdir -p build
     pushd build
+    # osx does not yet support caches, so we don't use ccache yet
+    if [[ $(uname -s) == 'Linux' ]]; then
+        # put mason installed ccache on PATH
+        # then osrm-backend will pick it up automatically
+        export CCACHE_VERSION="3.2.4"
+        ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+        export PATH=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})/bin:${PATH}
+    fi
     CMAKE_EXTRA_ARGS=""
     if [[ ${AR:-false} != false ]]; then
         CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_AR=${AR}"
@@ -114,7 +122,7 @@ function build_osrm() {
     if [[ ${NM:-false} != false ]]; then
         CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_NM=${NM}"
     fi
-    ../../../mason_packages/.link/bin/cmake ../ -DCMAKE_INSTALL_PREFIX=${MASON_HOME} \
+    ${MASON_HOME}/bin/cmake ../ -DCMAKE_INSTALL_PREFIX=${MASON_HOME} \
       -DCMAKE_CXX_COMPILER="$CXX" \
       -DBoost_NO_SYSTEM_PATHS=ON \
       -DTBB_INSTALL_DIR=${MASON_HOME} \


### PR DESCRIPTION
This enables `ccache` to help speed up recompiles on linux.

It also bumps the concurrency from 3->8 which is only possible with clang++ (g++ uses too much memory and the OOM killer strikes).

We are also looking at moving to clang++ as part of the c++14 effort (https://github.com/Project-OSRM/node-osrm/pull/153#issuecomment-194401873)

/cc @TheMarex @daniel-j-h 