### PR TITLE
Ensure consistent -std=c++11 compiler flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -21,6 +21,11 @@
       'defines': ['LIBOSRM_GIT_REVISION="<!@(pkg-config libosrm --modversion)"'],
       'conditions': [
         [ 'OS=="linux"', {
+          # remove the older style c++11 flag
+          # inherited by node >= 4.x
+          'cflags_cc!' : [
+              '-std=gnu++0x'
+          ],
           'cflags_cc' : [
               '-std=c++11'
           ],


### PR DESCRIPTION
Node 4x depends on v8 that requires c++11, but uses an older style c++11 flag. To ensure we only use one flag and to prepare for c++14 this change removes the flag coming from node's gyp config (that node-gyp inherits).