### PR TITLE
Back to gcc-4.8 until further testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
      - llvm-toolchain-precise-3.7
     packages:
      - coreutils
-     - clang-3.7
+     - g++-4.8
      - gdb
 
 # TODO: no core files on sudo:false machines until https://github.com/travis-ci/travis-ci/issues/3754 is resolved
@@ -27,13 +27,13 @@ matrix:
   include:
      # Linux
      - os: linux
-       compiler: ": clang-release-node-v4"
+       compiler: ": gcc-release-node-v4"
        env: NODE="4" TARGET=Release PUBLISHABLE=true
      - os: linux
-       compiler: ": clang-release-node-v0.10"
+       compiler: ": gcc-release-node-v0.10"
        env: NODE="0.10" TARGET=Release PUBLISHABLE=true
      - os: linux
-       compiler: ": clang-debug-node-v0.10"
+       compiler: ": gcc-debug-node-v0.10"
        env: NODE="0.10" TARGET=Debug PUBLISHABLE=true
      # OS X
      - os: osx
@@ -54,7 +54,7 @@ env:
   global:
    - CCACHE_TEMPDIR=/tmp/.ccache-temp
    - CCACHE_COMPRESS=1
-   - JOBS: "8"
+   - JOBS: "1"
    - secure: KitzGZjoDblX/3heajcvssGz0JnJ/k02dr2tu03ksUV+6MogC3RSQudqyKY57+f8VyZrcllN/UOlJ0Q/3iG38Oz8DljC+7RZxtkVmE1SFBoOezKCdhcvWM12G3uqPs7hhrRxuUgIh0C//YXEkulUrqa2H1Aj2xeen4E3FAqEoy0=
    - secure: WLGmxl6VTVWhXGm6X83GYNYzPNsvTD+9usJOKM5YBLAdG7cnOBQBNiCCUKc9OZMMZVUr3ec2/iigakH5Y8Yc+U6AlWKzlORyqWLuk4nFuoedu62x6ocQkTkuOc7mHiYhKd21xTGMYauaZRS6kugv4xkpGES2UjI2T8cjZ+LN2jU=
 
@@ -63,8 +63,8 @@ before_install:
 - export COVERAGE=${COVERAGE:-false}
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-    export CXX="clang++-3.7";
-    export CC="clang-3.7";
+    export CXX="g++-4.8";
+    export CC="gcc-4.8";
     export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python2.7/site-packages;
   elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     sudo sysctl -w kern.sysv.shmmax=4294967296


### PR DESCRIPTION
Move back to gcc-4.8 until further testing.

Using clang++-3.7 triggers libstdc++ `GLIBCXX_3.4.20` symbols being used/needed that are not available on the libstdc++ available by default on trusty. This can be solved on precise or trusty by upgrading libstdc++ on travis like:

```yml
addons:
   apt:
     sources:
      - ubuntu-toolchain-r-test
     packages:
      - libstdc++6 # upgrade libstdc++ on linux to support C++11
```

But I'll wait to re-enable clang-3.7 until further testing of that upgrade.