### PR TITLE
Avoid travis runs for tags to avoid re-running binary publishes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: generic
 git:
   depth: 10
 
+# don't re-build for tags so that [publish binary] is not re-run
+# https://github.com/travis-ci/travis-ci/issues/1532
+branches:
+  except:
+    - /^v[0-9]/
+
 cache:
   directories:
   - $HOME/.ccache


### PR DESCRIPTION
We are frequently:

  - Developing in branches
  - Publishing binaries from those branches
  - Tagging via branches

This change makes it so that travis will not build tags, so that we can safely have `[publish binary]` in a branch commit, tag from it, and then not have the builds for the tag fail/overwrite binaries.

/cc @TheMarex 