### PR TITLE
Travis builds: Properly pass --debug flag to node-pre-gyp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,16 +37,24 @@ matrix:
        env: NODE="0.10" TARGET=Debug PUBLISHABLE=true
      # OS X
      - os: osx
+       # https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
+       osx_image: xcode7.3 # upgrades clang from 6 -> 7
        compiler: clang
        env: NODE="4" TARGET=Release PUBLISHABLE=true
      - os: osx
+       # https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
+       osx_image: xcode7.3 # upgrades clang from 6 -> 7
        compiler: clang
        env: NODE="0.10" TARGET=Release PUBLISHABLE=true
      - os: osx
+       # https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
+       osx_image: xcode7.3 # upgrades clang from 6 -> 7
        compiler: clang
        env: NODE="0.10" TARGET=Debug PUBLISHABLE=true
      # Coverage
      - os: osx
+       # https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions
+       osx_image: xcode7.3 # upgrades clang from 6 -> 7
        compiler: clang
        env: NODE="0.10" COVERAGE=true TARGET=Debug PUBLISHABLE=false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ env:
 before_install:
 - scripts/validate_tag.sh
 - export COVERAGE=${COVERAGE:-false}
+- if [[ ${TARGET} == 'Debug' ]]; then export NPM_FLAGS="--debug"; else export NPM_FLAGS="" fi;
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
     export CXX="g++-4.8";

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
 before_install:
 - scripts/validate_tag.sh
 - export COVERAGE=${COVERAGE:-false}
-- if [[ ${TARGET} == 'Debug' ]]; then export NPM_FLAGS="--debug"; else export NPM_FLAGS="" fi;
+- if [[ ${TARGET} == 'Debug' ]]; then export NPM_FLAGS="--debug"; else export NPM_FLAGS=""; fi;
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
     export CXX="g++-4.8";

--- a/Makefile
+++ b/Makefile
@@ -46,20 +46,20 @@ endif
 build/Release/osrm.node: ./node_modules ./deps/osrm-backend-Release
 	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \
 	  echo "*** Using osrm installed at `pkg-config libosrm --variable=prefix` ***" && \
-	  ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang=1
+	  ./node_modules/.bin/node-pre-gyp configure build --loglevel=error --clang=1 $(NPM_FLAGS)
 
 # put the local debug-built osrm-backend on PKG_CONFIG_PATH and build as normal
 debug: ./node_modules ./deps/osrm-backend-Debug
 	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \
 	  echo "*** Using osrm installed at `pkg-config libosrm --variable=prefix` ***" && \
-	  ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1
+	  ./node_modules/.bin/node-pre-gyp configure build --debug --clang=1 $(NPM_FLAGS)
 
 # same as typing "make" (which hits the "build/Release/osrm.node" target) except that
 # "--loglevel=verbose" shows the actual compiler arguments
 verbose: ./node_modules ./deps/osrm-backend-Release
 	@export PKG_CONFIG_PATH="mason_packages/.link/lib/pkgconfig" && \
 	  echo "*** Using osrm installed at `pkg-config libosrm --variable=prefix` ***" && \
-	  ./node_modules/.bin/node-pre-gyp configure build --loglevel=verbose --clang=1
+	  ./node_modules/.bin/node-pre-gyp configure build --loglevel=verbose --clang=1 $(NPM_FLAGS)
 
 clean:
 	(cd test/data/ && $(MAKE) clean)

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,19 +1,25 @@
 #!/bin/bash
 
+echo "dumping binary meta..."
+./node_modules/.bin/node-pre-gyp reveal ${NPM_FLAGS}
+
+echo "determining publishing status..."
+
 if [[ $(./scripts/is_pr_merge.sh) ]]; then
     echo "Skipping publishing because this is a PR merge commit"
 else
-    ./node_modules/.bin/node-pre-gyp package
+    echo "This is a push commit, continuing to package..."
+    ./node_modules/.bin/node-pre-gyp package ${NPM_FLAGS}
 
     COMMIT_MESSAGE=$(git log --format=%B --no-merges | head -n 1 | tr -d '\n')
     echo "Commit message: ${COMMIT_MESSAGE}"
 
     if [[ ${COMMIT_MESSAGE} =~ "[publish binary]" ]]; then
         echo "Publishing"
-        ./node_modules/.bin/node-pre-gyp publish
+        ./node_modules/.bin/node-pre-gyp publish ${NPM_FLAGS}
     elif [[ ${COMMIT_MESSAGE} =~ "[republish binary]" ]]; then
         echo "Re-Publishing"
-        ./node_modules/.bin/node-pre-gyp unpublish publish
+        ./node_modules/.bin/node-pre-gyp unpublish publish ${NPM_FLAGS}
     else
         echo "Skipping publishing"
     fi;


### PR DESCRIPTION
Fixes #174

Avoids travis-built Debug builds from conflicting with Release builds.