### PR TITLE
Removes Locate service example from Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,6 @@ Once that is done then you can calculate routes in Javascript like:
 var OSRM = require('osrm')
 var osrm = new OSRM("berlin-latest.osrm");
 
-osrm.locate([52.4224,13.333086], function (err, result) {
-  console.log(result);
-  // Output: {"status":0,"mapped_coordinate":[52.422442,13.332101]}
-});
-
 osrm.nearest([52.4224, 13.333086], function (err, result) {
   console.log(result);
   // Output: {"status":0,"mapped_coordinate":[52.422590,13.333838],"name":"Mariannenstraße"}


### PR DESCRIPTION
The Locate service is long gone from OSRM, as it would have required
quite some work in the RTree. It's gone for probably a year now.

I'm wondering why not a single user reported the first example in
the README being broken so far.