### PR TITLE
Fix rpath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,14 +88,16 @@ install:
 - if [[ ${COVERAGE} == true ]]; then
     PYTHONUSERBASE=$(pwd)/mason_packages/.link pip install --user cpp-coveralls;
   fi;
-- CMD="make"
 - |
   if [[ ${TARGET} == 'Debug' ]]; then
-    CMD="${CMD} debug";
+    export BUILD_TYPE=Debug && source ./bootstrap.sh
   elif [[ ${COVERAGE} == true ]]; then
-    CMD="${CMD} coverage";
+    export BUILD_TYPE=Debug && source ./bootstrap.sh
+    export LDFLAGS="--coverage" && export CXXFLAGS="--coverage"
+  else
+    source ./bootstrap.sh
   fi
-- ${CMD}
+- npm install --build-from-source ${NPM_FLAGS} --clang=1
 
 before_script:
 - ulimit -c unlimited -S

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -177,6 +177,8 @@ function main() {
     LINK_FLAGS=""
     if [[ $(uname -s) == 'Linux' ]]; then
         LINK_FLAGS="${LINK_FLAGS} "'-Wl,-z,origin -Wl,-rpath=\$ORIGIN'
+        # ensure rpath is picked up by node-osrm build
+        export LDFLAGS='-Wl,-z,origin -Wl,-rpath=\$$ORIGIN '${LDFLAGS}
     fi
 
     build_osrm

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,6 +3,20 @@
 echo "dumping binary meta..."
 ./node_modules/.bin/node-pre-gyp reveal ${NPM_FLAGS}
 
+# enforce that binary has proper ORIGIN flags so that
+# it can portably find libtbb.so in the same directory
+if [[ $(uname -s) == 'Linux' ]]; then
+    readelf -d ./lib/binding/osrm.node > readelf-output.txt
+    if grep -q 'Flags: ORIGIN' readelf-output.txt; then
+        echo "Found ORIGIN flag in readelf output"
+        cat readelf-output.txt
+    else
+        echo "*** Error: Could not found ORIGIN flag in readelf output"
+        cat readelf-output.txt
+        exit 1
+    fi
+fi
+
 echo "determining publishing status..."
 
 if [[ $(./scripts/is_pr_merge.sh) ]]; then


### PR DESCRIPTION
Rpath logic was broken. We were still ending up with portable binaries because the linker was dropping libtbb due to it not being used in the code. However when we move to a new compiler this will break.