### PR TITLE
Restrict bearing range to 0..180

### DIFF
--- a/src/node_osrm_support.hpp
+++ b/src/node_osrm_support.hpp
@@ -294,8 +294,8 @@ inline bool argumentsToParameter(const Nan::FunctionCallbackInfo<v8::Value> &arg
                     short bearing_first = static_cast<short>(bearing_pair->Get(0)->NumberValue());
                     short bearing_second = static_cast<short>(bearing_pair->Get(1)->NumberValue());
 
-                    if (bearing_first < 0 || bearing_first >= 360 || bearing_second < 0 ||
-                        bearing_second >= 360)
+                    if (bearing_first < 0 || bearing_first > 360 || bearing_second < 0 ||
+                        bearing_second > 360)
                     {
                         Nan::ThrowError("Bearing values need to be in range 0..360");
                         return false;

--- a/src/node_osrm_support.hpp
+++ b/src/node_osrm_support.hpp
@@ -291,17 +291,16 @@ inline bool argumentsToParameter(const Nan::FunctionCallbackInfo<v8::Value> &arg
                         return false;
                     }
 
-                    short bearing_first = static_cast<short>(bearing_pair->Get(0)->NumberValue());
-                    short bearing_second = static_cast<short>(bearing_pair->Get(1)->NumberValue());
+                    const auto bearing = static_cast<short>(bearing_pair->Get(0)->NumberValue());
+                    const auto range = static_cast<short>(bearing_pair->Get(1)->NumberValue());
 
-                    if (bearing_first < 0 || bearing_first > 360 || bearing_second < 0 ||
-                        bearing_second > 360)
+                    if (bearing < 0 || bearing > 360 || range < 0 || range > 180)
                     {
-                        Nan::ThrowError("Bearing values need to be in range 0..360");
+                        Nan::ThrowError("Bearing values need to be in range 0..360, 0..180");
                         return false;
                     }
 
-                    params->bearings.push_back(osrm::Bearing{bearing_first, bearing_second});
+                    params->bearings.push_back(osrm::Bearing{bearing, range});
                 }
                 else
                 {

--- a/test/route.js
+++ b/test/route.js
@@ -207,7 +207,7 @@ test('route: valid bearing values', function(assert) {
         assert.ifError(err);
         assert.ok(route.routes[0]);
     });
-    options.bearings = [null, [250, 180]];
+    options.bearings = [null, [360, 180]];
     osrm.route(options, function(err, route) {
         assert.ifError(err);
         assert.ok(route.routes[0]);

--- a/test/route.js
+++ b/test/route.js
@@ -221,7 +221,7 @@ test('route: invalid bearing values', function(assert) {
         coordinates: [[13.43864,52.51993],[13.415852,52.513191]],
         bearings: [[400, 180], [-250, 180]],
     }, function(err, route) {}) },
-        /Bearing values need to be in range 0..360/);
+        /Bearing values need to be in range 0..360, 0..180/);
     assert.throws(function() { osrm.route({
         coordinates: [[13.43864,52.51993],[13.415852,52.513191]],
         bearings: [[200], [250, 180]],
@@ -231,7 +231,7 @@ test('route: invalid bearing values', function(assert) {
         coordinates: [[13.43864,52.51993],[13.415852,52.513191]],
         bearings: [[400, 109], [100, 720]],
     }, function(err, route) {}) },
-        /Bearing values need to be in range 0..360/);
+        /Bearing values need to be in range 0..360, 0..180/);
     assert.throws(function() { osrm.route({
         coordinates: [[13.43864,52.51993],[13.415852,52.513191]],
         bearings: 400,


### PR DESCRIPTION
During investigating https://github.com/Project-OSRM/node-osrm/pull/199 it turned out we do not restrict bearing range values to 0..180.

https://github.com/Project-OSRM/osrm-backend/blob/503137221d88eabe87de61f83b5b782e371e3121/include/engine/bearing.hpp#L41