### PR TITLE
Pin osrm-backend v5.2.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.2.0-rc.1",
+  "version": "5.2.0-rc.2",
   "osrm_release" : "master",
   "main": "./lib/osrm.js",
   "license": "BSD",

--- a/test/data/data.md5sum
+++ b/test/data/data.md5sum
@@ -1,4 +1,4 @@
 011ac454d10f0ff0194e4928d6f9c348  lib/access.lua
 997270b082774ecc179ccb504a59e87c  lib/destination.lua
-28d6daf1a96a477c873be015e11e6dea  car.lua
+1d1790e582810178a0a7bdd671119cec  car.lua
 045af81d07eb9f22e5718db13cf337e4  berlin-latest.osm.pbf


### PR DESCRIPTION
If this build is passing on Travis
- [ ] merge into master
- [ ] publish binaries to npm
- [ ] tag v5.2.0-rc.2 in node-osrm