### PR TITLE
need to update license term in NPM build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "version": "5.3.0-rc.2",
   "osrm_release" : "master",
   "main": "./lib/osrm.js",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "bugs": {
     "email": "dane@mapbox.com",
     "url": "https://github.com/Project-OSRM/node-osrm/issues"


### PR DESCRIPTION
builds currently throwing with 

npm WARN osrm@5.3.0-rc.2 license should be a valid SPDX license expression
