### PR TITLE
Fix travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ branches:
     - /^v[0-9]/
 
 cache:
-  apt: true
-  ccache: true
+  directories:
+  - $HOME/.ccache
+  - test/data
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ before_install:
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
     export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python2.7/site-packages;
   elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+    rvm get head || true
     sudo sysctl -w kern.sysv.shmmax=4294967296
     sudo sysctl -w kern.sysv.shmall=1048576
     sudo sysctl -w kern.sysv.shmseg=128


### PR DESCRIPTION
Applies a similar fix as https://github.com/Project-OSRM/osrm-backend/pull/2658

This sped up build times significantly:

 - linux/release 9:50 -> 3:06
 - linux/debug  11:56 -> 4:44
 - osx/release  15:17 -> 7:44
 - osx/debug   20:33 -> 7:03
 