### PR TITLE
Add config for circleci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ env:
   global:
    - CCACHE_TEMPDIR=/tmp/.ccache-temp
    - CCACHE_COMPRESS=1
-   - JOBS=2
    - secure: KitzGZjoDblX/3heajcvssGz0JnJ/k02dr2tu03ksUV+6MogC3RSQudqyKY57+f8VyZrcllN/UOlJ0Q/3iG38Oz8DljC+7RZxtkVmE1SFBoOezKCdhcvWM12G3uqPs7hhrRxuUgIh0C//YXEkulUrqa2H1Aj2xeen4E3FAqEoy0=
    - secure: WLGmxl6VTVWhXGm6X83GYNYzPNsvTD+9usJOKM5YBLAdG7cnOBQBNiCCUKc9OZMMZVUr3ec2/iigakH5Y8Yc+U6AlWKzlORyqWLuk4nFuoedu62x6ocQkTkuOc7mHiYhKd21xTGMYauaZRS6kugv4xkpGES2UjI2T8cjZ+LN2jU=
 
@@ -75,7 +74,12 @@ before_install:
 - scripts/validate_tag.sh
 
 install:
-- scripts/build.sh
+- |
+  if [[ "$(uname -s)" == "Linux" ]]; then
+    JOBS=2 ./scripts/build.sh
+  else
+    JOBS=4 ./scripts/build.sh
+  fi
 
 script:
 - if [[ ${COVERAGE} == true ]]; then

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,6 @@ dependencies:
     - '~/.ccache'
     - '~/.apt-cache'
     - 'test/data'
-    - 'mason_packages'
   pre:
     - |
       if [[ "$(uname -s)" == "Linux" ]]; then

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,41 @@
+machine:
+  xcode:
+    version: 7.3
+  environment:
+    XCODE_SCHEME: "no"
+    XCODE_WORKSPACE: "no"
+    CCACHE_COMPRESS: 1
+
+dependencies:
+  cache_directories:
+    - '~/.ccache'
+    - '~/.apt-cache'
+    - 'test/data'
+    - 'mason_packages'
+  pre:
+    - |
+      if [[ "$(uname -s)" == "Linux" ]]; then
+        echo "Setting up apt-cache on linux"
+        # https://discuss.circleci.com/t/add-ability-to-cache-apt-get-programs/598/3
+        sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        sudo apt-get update -y
+        echo "Installing apt deps"
+        sudo apt-get install -y g++-4.8 pkg-config wget ccache
+      else
+        brew install pkg-config wget ccache || true
+      fi
+
+  override:
+    - which ccache
+    - ccache -s
+    - |
+      if [[ "$(uname -s)" == "Linux" ]]; then
+        JOBS=2 CXX=g++-4.8 CC=gcc-4.8 ./scripts/build.sh
+      else
+        JOBS=4 CXX=clang++ CC=clang ./scripts/build.sh
+      fi
+
+test:
+  override:
+    - echo "success"


### PR DESCRIPTION
Refs #162 

- Works for both OS X, `Ubuntu 12.04 (Precise)`, and `Ubuntu 14.04 (Trusty)`
- Same exact script runs on travis and circleci now: https://github.com/Project-OSRM/node-osrm/blob/90060510c3c2ad2169a4ba0c06ccc3b64de8950b/scripts/build.sh
- Currently enabled to run on OS X only at https://circleci.com/gh/Project-OSRM/node-osrm/edit#build-environment

Compared to travis:

| Circle CI        |             Travis |
| ------------- | ------------- |
|  OSX release: 2:30  |  OSX release: 7:44  |
|  Linux release: 2:09  | Linux release: 3:06  |

- * Above times are not averages, just the fastest seen during testing. TIMES MAY VARY.
- ** Above times reflect rebuilds without any code changes, so `ccache` is helping significantly. For builds that involve major code changes TIMES MAY VARY.