### PR TITLE
Enable coverage+codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,14 @@ matrix:
       osx_image: xcode8 # upgrades clang from 6 -> 7
       compiler: clang
       env: NODE="4" TARGET=Debug PUBLISHABLE=true
+    # Linux coverage build
+    - os: linux
+      compiler: ": clang38-debug-coverage-node-v4"
+      env: NODE="4" TARGET=Debug CC="clang-3.8" CXX="clang++-3.8" COVERAGE=true PUBLISHABLE=false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-5-dev', 'apport', 'gdb' ]
 
 env:
   global:
@@ -88,9 +96,13 @@ install:
   fi
 
 script:
-- if [[ ${COVERAGE} == true ]]; then
-    ./mason_packages/.link/bin/cpp-coveralls --gcov /usr/bin/llvm-cov-3.5 --exclude __nvm --exclude node_modules --exclude mason_packages --exclude tests --build-root build --gcov-options '\-lp' --exclude doc --exclude build/Release/obj/gen;
-  fi;
 - if [[ ${PUBLISHABLE} == true ]]; then
     ./scripts/publish.sh;
   fi;
+- |
+  if [ -n "${COVERAGE}" ]; then
+    which llvm-cov
+    curl -S -f https://codecov.io/bash -o codecov
+    chmod +x codecov
+    ./codecov -x "llvm-cov gcov" -Z
+  fi

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provides read-only bindings to the [Open Source Routing Machine - OSRM](https://
 
 | build config | status |
 |:-------------|:------------|
-| Linux/OS X   | [![Build Status](https://travis-ci.org/Project-OSRM/node-osrm.svg?branch=master)](https://travis-ci.org/Project-OSRM/node-osrm) [![Coverage Status](https://coveralls.io/repos/Project-OSRM/node-osrm/badge.svg?branch=master)](https://coveralls.io/r/Project-OSRM/node-osrm?branch=master) |
+| Linux/OS X   | [![Build Status](https://travis-ci.org/Project-OSRM/node-osrm.svg?branch=master)](https://travis-ci.org/Project-OSRM/node-osrm) [![codecov](https://codecov.io/gh/Project-OSRM/node-osrm/branch/master/graph/badge.svg)](https://codecov.io/gh/Project-OSRM/node-osrm) |
 
 # Documentation
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,9 +34,7 @@ else
     export NPM_FLAGS=""
 fi
 
-if [[ "$(uname -s)" == "Linux" ]]; then
-    export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python2.7/site-packages
-elif [[ "$(uname -s)" == "Darwin" ]]; then
+if [[ "$(uname -s)" == "Darwin" ]]; then
     if [[ -f /etc/sysctl.conf ]] && [[ $(grep shmmax /etc/sysctl.conf) ]]; then
         echo "Note: found shmmax setting in /etc/sysctl.conf, not modifying"
     else
@@ -44,23 +42,18 @@ elif [[ "$(uname -s)" == "Darwin" ]]; then
         sudo sysctl -w kern.sysv.shmmax=4294967296
         sudo sysctl -w kern.sysv.shmall=1048576
         sudo sysctl -w kern.sysv.shmseg=128
-        export PYTHONPATH=$(pwd)/mason_packages/.link/lib/python/site-packages
         brew install md5sha1sum
     fi
-fi
-
-if [[ ${COVERAGE} == true ]]; then
-    PYTHONUSERBASE=$(pwd)/mason_packages/.link pip install --user cpp-coveralls
 fi
 
 # install consistent node version
 source ./scripts/install_node.sh ${NODE}
 
 if [[ ${TARGET} == 'Debug' ]]; then
+    if [[ ${COVERAGE} == true ]]; then
+        export LDFLAGS="${LDFLAGS:-} --coverage" && export CXXFLAGS="${CXXFLAGS:-} --coverage"
+    fi
     export BUILD_TYPE=Debug && source ./bootstrap.sh
-elif [[ ${COVERAGE} == true ]]; then
-    export BUILD_TYPE=Debug && source ./bootstrap.sh
-    export LDFLAGS="--coverage" && export CXXFLAGS="--coverage"
 else
     source ./bootstrap.sh
 fi


### PR DESCRIPTION
This PR removes the broken and disabled coverage reporting that previously used coveralls and moves to using codcov.io. This is worthwhile because coveralls was not scaling well for several reasons:

  - Often the service would timeout so the post of data would fail
  - The cpp-coveralls tool breaks with llvm > 3.5 (not found a solution here, so moving to codecov works around this).

Closes #222