### PR TITLE
Only set coverage flags for node-osrm

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,12 +50,15 @@ fi
 source ./scripts/install_node.sh ${NODE}
 
 if [[ ${TARGET} == 'Debug' ]]; then
-    if [[ ${COVERAGE} == true ]]; then
-        export LDFLAGS="${LDFLAGS:-} --coverage" && export CXXFLAGS="${CXXFLAGS:-} --coverage"
-    fi
     export BUILD_TYPE=Debug && source ./bootstrap.sh
 else
     source ./bootstrap.sh
+fi
+
+# only set coverage flags for node-osrm to avoid
+# very slow performance for osrm command line tools
+if [[ ${COVERAGE} == true ]]; then
+    export LDFLAGS="${LDFLAGS:-} --coverage" && export CXXFLAGS="${CXXFLAGS:-} --coverage"
 fi
 
 npm install --build-from-source ${NPM_FLAGS} --clang=1


### PR DESCRIPTION
This is a followup to #228. In #228 I got coverage reporting working with llvm-cov-3.8 + codecov.io. Once side effect was that the `--coverage` flag was passed to the `osrm-backend` build. This is unneeded and was causing the tests to run very slowly. This fixes the slow travis run by restricting the `--coverage` flag to the node-osrm build.