### PR TITLE
See if API change breaks Node bindings: Do Not Merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
   "version": "5.3.0",
-  "osrm_release" : "v5.3.0",
+  "osrm_release" : "threadsafe-interface",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {


### PR DESCRIPTION
Small change in `libosrm`'s API: lifting `const`nes constraints. Let's have Travis build it. Do not merge.

See https://github.com/Project-OSRM/osrm-backend/pull/2862#issuecomment-245275942