### PR TITLE
Drop md5sha1sum dependency in tests

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,6 +24,11 @@ if [[ ! $(which wget) ]]; then
     exit 1;
 fi;
 
+if [[ ! $(which md5sum) ]]; then
+    echo "echo md5sum must be installed";
+    exit 1;
+fi;
+
 if [[ ! $(which pkg-config) ]]; then
     echo "echo pkg-config must be installed";
     exit 1;
@@ -37,7 +42,6 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
         sudo sysctl -w kern.sysv.shmmax=4294967296
         sudo sysctl -w kern.sysv.shmall=1048576
         sudo sysctl -w kern.sysv.shmseg=128
-        mapbox_time "brew" brew install md5sha1sum
     fi
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -24,11 +24,6 @@ if [[ ! $(which wget) ]]; then
     exit 1;
 fi;
 
-if [[ ! $(which md5sum) ]]; then
-    echo "echo md5sum must be installed";
-    exit 1;
-fi;
-
 if [[ ! $(which pkg-config) ]]; then
     echo "echo pkg-config must be installed";
     exit 1;

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -33,7 +33,7 @@ berlin-latest.osm.pbf:
 
 berlin-latest.osrm: berlin-latest.osm.pbf car.lua $(OSRM_EXTRACT)
 	@echo "Verifiyng data file integrity..."
-	md5sum -c data.md5sum
+	node md5sum.js data.md5sum
 	@PATH="${PATH}:../../lib/binding" && echo "*** Using osrm-extract from `which osrm-extract` ***"
 	@echo "Running osrm-extract..."
 	@PATH="${PATH}:../../lib/binding" && osrm-extract berlin-latest.osm.pbf -p car.lua

--- a/test/data/md5sum.js
+++ b/test/data/md5sum.js
@@ -1,0 +1,69 @@
+'use strict'
+
+var crypto = require('crypto');
+var fs = require('fs');
+
+if (process.argv.length < 3) {
+    console.error('Please pass path to data.md5sum file to use to validate');
+    process.exit(1);
+}
+
+var BUFFER_SIZE = 8192
+
+function md5FileSync (filename) {
+  var fd = fs.openSync(filename, 'r')
+  var hash = crypto.createHash('md5')
+  var buffer = new Buffer(BUFFER_SIZE)
+
+  try {
+    var bytesRead
+
+    do {
+      bytesRead = fs.readSync(fd, buffer, 0, BUFFER_SIZE)
+      hash.update(buffer.slice(0, bytesRead))
+    } while (bytesRead === BUFFER_SIZE)
+  } finally {
+    fs.closeSync(fd)
+  }
+
+  return hash.digest('hex')
+}
+
+var validate_file = process.argv[2];
+
+var sums = {};
+var lines = fs.readFileSync(validate_file).
+  toString().
+  split('\n').
+  filter(function(line) {
+    return line !== "";
+});
+
+var error = 0;
+
+lines.forEach(function(line) {
+    var parts = line.split('  ');
+    var filename = parts[1];
+    var md5 = parts[0];
+    sums[filename] = md5;
+    var md5_actual = md5FileSync(filename);
+    if (md5_actual !== md5) {
+        error++;
+    } else {
+        console.log(filename + ': OK');
+    }
+})
+
+if (error > 0) {
+    console.error('ms5sum.js WARNING: 1 computed checksum did NOT match');
+    console.error('\nExpected:')
+    lines.forEach(function(line) {
+        var parts = line.split('  ');
+        var filename = parts[1];
+        var md5 = parts[0];
+        console.log(md5 + '  ' + filename);
+    })
+    process.exit(1);
+} else {
+    process.exit(0);
+}

--- a/test/data/md5sum.js
+++ b/test/data/md5sum.js
@@ -49,6 +49,7 @@ lines.forEach(function(line) {
     var md5_actual = md5FileSync(filename);
     if (md5_actual !== md5) {
         error++;
+        console.error(filename + ': FAILED')
     } else {
         console.log(filename + ': OK');
     }


### PR DESCRIPTION
This replaces the `brew install md5sha1sum` step which:

  - Is currently failing due to changes in homebrew unrelated to node-osrm: #245
  - And also is wrong: I think it should have been `brew install coreutils` instead.
  - But this removes the need for the external dependency completely by replacing with a cross-platform node.js script.