### PR TITLE
Ensure node version proprogates to publish script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ addons_default: &apt_packages
     packages: [ 'libstdc++-5-dev', 'apport', 'gdb' ]
 
 script_default: &build_and_publish
-    - ./scripts/build.sh
+    - source ./scripts/build.sh
     - ./scripts/publish.sh
 
 matrix:

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,6 +6,10 @@ set -o pipefail
 # should be set for debug builds
 export NPM_FLAGS=${NPM_FLAGS:-}
 
+echo "node version is:"
+which node
+node -v
+
 echo "dumping binary meta..."
 ./node_modules/.bin/node-pre-gyp reveal ${NPM_FLAGS}
 


### PR DESCRIPTION
 - Fixes regression from dd322ab4 whereby the correct node version (the one installed by nvm) was no longer on PATH and was defaulting to the system node (v0.10.x)