### PR TITLE
5.4 lua down

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -45,8 +45,8 @@ echo
 
 function all_deps() {
     dep cmake 3.2.2 &
-    dep lua 5.3.0 &
-    dep luabind e414c57bcb687bb3091b7c55bbff6947f052e46b &
+    dep lua 5.2.4 &
+    dep luabind_lua524 e414c57bcb687bb3091b7c55bbff6947f052e46b &
     dep boost 1.61.0 &
     dep boost_libsystem 1.61.0 &
     dep boost_libthread 1.61.0 &

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
   "version": "5.4.0-rc.4",
-  "osrm_release" : "v5.4.0-rc.4",
+  "osrm_release" : "v5.4.0-rc.4-luadown",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.4.0-rc.4",
-  "osrm_release" : "v5.4.0-rc.4-luadown",
+  "version": "5.4.0-rc.4-luadown",
+  "osrm_release" : "v5.4.0-rc.4",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/scripts/setup_mason.sh
+++ b/scripts/setup_mason.sh
@@ -4,7 +4,7 @@ set -eu
 set -o pipefail
 
 # we pin the mason version to avoid changes in mason breaking builds
-MASON_VERSION="0ad8ab4"
+MASON_VERSION="osrm-test1"
 
 function setup_mason() {
     if [[ ! -d ./.mason ]]; then


### PR DESCRIPTION
Pulling in the changes from @springmeyer's branch trying to resolve https://github.com/Project-OSRM/osrm-backend/issues/2926. I will release `5.4.0.rc-5` from this. If it doesn't pan out, we will revert these changes again.

Todo post-merge:

- [ ] Update versions on `5.4` branch
- [ ] We test if this actually fixes https://github.com/Project-OSRM/osrm-backend/issues/2926
- [ ] @springmeyer to release the changes to mason under a proper version
- [ ] update `node-osrm` to mason and make a new release candidate from that

/cc @springmeyer @jakepruitt @karenzshea @MoKob @daniel-j-h 