### PR TITLE
5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## node-osrm changelog
+### v5.4.0-rc.3
+  - Update to osrm-backend v5.4.0-rc.3
+
 ### v5.4.0-rc.2
   - Update to osrm-backend v5.4.0-rc.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## node-osrm changelog
+### v5.4.0-rc.1
+ - Update to osrm-backend v5.4.0-rc.1
+ - New *.lua dependency lib/guidance.lua
 
 ### v5.3.0
  - Update to osrm-backend v5.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## node-osrm changelog
+
+### v5.4.0-rc.5
+  - downgrade lua to 5.2.4
+  - Update to osrm-backend v5.4.0-rc.5
+
 ### v5.4.0-rc.4
   - Update to osrm-backend v5.4.0-rc.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## node-osrm changelog
+### v5.4.0-rc.4
+  - Update to osrm-backend v5.4.0-rc.4
+
 ### v5.4.0-rc.3
   - Update to osrm-backend v5.4.0-rc.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## node-osrm changelog
+### v5.4.0-rc.2
+  - Update to osrm-backend v5.4.0-rc.2
+
 ### v5.4.0-rc.1
  - Update to osrm-backend v5.4.0-rc.1
  - New *.lua dependency lib/guidance.lua

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.4.0-rc.1",
-  "osrm_release" : "v5.4.0-rc.1",
+  "version": "5.4.0-rc.2",
+  "osrm_release" : "v5.4.0-rc.2",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
   "version": "5.4.0-rc.4",
-  "osrm_release" : "v5.4.0-rc.4",
+  "osrm_release" : "v5.4.0-rc.4-luadown",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.4.0-rc.2",
-  "osrm_release" : "v5.4.0-rc.2",
+  "version": "5.4.0-rc.3",
+  "osrm_release" : "v5.4.0-rc.3",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.4.0-rc.4",
-  "osrm_release" : "v5.4.0-rc.4-luadown",
+  "version": "5.4.0-rc.4-luadown",
+  "osrm_release" : "v5.4.0-rc.4",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.4.0-rc.3",
-  "osrm_release" : "v5.4.0-rc.3",
+  "version": "5.4.0-rc.4",
+  "osrm_release" : "v5.4.0-rc.4",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.3.0",
-  "osrm_release" : "v5.3.0",
+  "version": "5.4.0-rc.1",
+  "osrm_release" : "v5.4.0-rc.1",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.4.0-rc.4-luadown",
-  "osrm_release" : "v5.4.0-rc.4",
+  "version": "5.4.0-rc.5",
+  "osrm_release" : "v5.4.0-rc.5",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",
   "bugs": {

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -6,6 +6,7 @@ $(error OSRM_RELEASE variable was not correct set)
 endif
 
 CAR_PROFILE_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/car.lua
+LIB_GUIDANCE_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/lib/guidance.lua
 PROFILE_LIB_ACCESS_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/lib/access.lua
 PROFILE_LIB_DESTINATION_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles/lib/destination.lua
 BERLIN_URL:=https://s3.amazonaws.com/mapbox/node-osrm/testing/berlin-latest.osm.pbf
@@ -20,7 +21,10 @@ lib/access.lua:
 	mkdir -p lib
 	wget $(PROFILE_LIB_ACCESS_URL) -O lib/access.lua
 
-car.lua: lib/access.lua lib/destination.lua
+lib/guidance.lua:
+	wget $(LIB_GUIDANCE_URL) -O lib/guidance.lua
+
+car.lua: lib/access.lua lib/destination.lua lib/guidance.lua
 	wget $(CAR_PROFILE_URL) -O car.lua
 
 clean:

--- a/test/data/data.md5sum
+++ b/test/data/data.md5sum
@@ -1,5 +1,0 @@
-011ac454d10f0ff0194e4928d6f9c348  lib/access.lua
-997270b082774ecc179ccb504a59e87c  lib/destination.lua
-c7ee15d26d403d20710cfa8ac1b1144c  lib/guidance.lua
-ac8702ab61df224f5b4664184b87e52f  car.lua
-045af81d07eb9f22e5718db13cf337e4  berlin-latest.osm.pbf

--- a/test/data/data.md5sum
+++ b/test/data/data.md5sum
@@ -1,0 +1,5 @@
+011ac454d10f0ff0194e4928d6f9c348  lib/access.lua
+997270b082774ecc179ccb504a59e87c  lib/destination.lua
+c7ee15d26d403d20710cfa8ac1b1144c  lib/guidance.lua
+833f482fc35f34b0cc2a82db57fd519f  car.lua
+045af81d07eb9f22e5718db13cf337e4  berlin-latest.osm.pbf

--- a/test/data/data.md5sum
+++ b/test/data/data.md5sum
@@ -1,4 +1,5 @@
 011ac454d10f0ff0194e4928d6f9c348  lib/access.lua
 997270b082774ecc179ccb504a59e87c  lib/destination.lua
-3ef5f066b6814cbaa306e01097f9243a  car.lua
+c7ee15d26d403d20710cfa8ac1b1144c  lib/guidance.lua
+ac8702ab61df224f5b4664184b87e52f  car.lua
 045af81d07eb9f22e5718db13cf337e4  berlin-latest.osm.pbf

--- a/test/tile.js
+++ b/test/tile.js
@@ -7,6 +7,6 @@ test('tile', function(assert) {
     var osrm = new OSRM(berlin_path);
     osrm.tile([17603, 10747, 15], function(err, result) {
         assert.ifError(err);
-        assert.equal(result.length, 20703);
+        assert.equal(result.length, 20717);
     });
 });


### PR DESCRIPTION
New PR, rebased against latest master, targeting the 5.4.0 release.

 - Downgrades to lua 5.2 to reduce memory usage and increase performance compared to lua 5.3
 - Includes updated mason binaries for lua 5.2 that were built with `-O3` for best speed
 - Targeting osrm-backend@v5.4.0

@MoKob @freenerd - feel free to use this branch for further 5.4.0 release candidates, or merge this into your existing `5.4` branch. Either way I think we should pull in latest master, which this does. But I did not want to do that directly into `5.4` before testing that travis passed and before syncing with you tomorrow.