### PR TITLE
Fix the checksum command to include lib/guidance.lua

### DIFF
--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -48,6 +48,6 @@ berlin-latest.osrm.hsgr: berlin-latest.osrm car.lua $(OSRM_CONTRACT)
 	@PATH="${PATH}:../../lib/binding" && osrm-contract berlin-latest.osrm
 
 checksum: car.lua lib/destination.lua lib/access.lua lib/guidance.lua berlin-latest.osm.pbf
-	md5sum car.lua lib/destination.lua lib/access.lua lib/guidance.lua berlin-latest.osm.pbf > data.md5sum
+	md5sum $^ > data.md5sum
 
 .PHONY: clean checksum

--- a/test/data/Makefile
+++ b/test/data/Makefile
@@ -47,7 +47,7 @@ berlin-latest.osrm.hsgr: berlin-latest.osrm car.lua $(OSRM_CONTRACT)
 	@echo "Running osrm-contract..."
 	@PATH="${PATH}:../../lib/binding" && osrm-contract berlin-latest.osrm
 
-checksum:
-	md5sum lib/access.lua lib/destination.lua car.lua berlin-latest.osm.pbf > data.md5sum
+checksum: car.lua lib/destination.lua lib/access.lua lib/guidance.lua berlin-latest.osm.pbf
+	md5sum car.lua lib/destination.lua lib/access.lua lib/guidance.lua berlin-latest.osm.pbf > data.md5sum
 
 .PHONY: clean checksum


### PR DESCRIPTION
Minor fix to the `make checksum` command in the `test/Makefile`. This command is only used manually by a developer when the checksum file needs regenerated. But it was broken, so this fixes it.