### PR TITLE
Set GLIBCXX_USE_CXX11_ABI=0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -129,6 +129,7 @@ function build_osrm() {
       -DCMAKE_CXX_COMPILER="$CXX" \
       -DBoost_NO_SYSTEM_PATHS=ON \
       -DTBB_INSTALL_DIR=${MASON_HOME} \
+      -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
       -DCMAKE_INCLUDE_PATH=${MASON_HOME}/include \
       -DCMAKE_LIBRARY_PATH=${MASON_HOME}/lib \
       -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
@@ -161,6 +162,8 @@ function main() {
     export C_INCLUDE_PATH="${MASON_HOME}/include"
     export CPLUS_INCLUDE_PATH="${MASON_HOME}/include"
     export LIBRARY_PATH="${MASON_HOME}/lib"
+
+    export CXXFLAGS="${CXXFLAGS:-} -D_GLIBCXX_USE_CXX11_ABI=0"
 
     LINK_FLAGS=""
     if [[ $(uname -s) == 'Linux' ]]; then


### PR DESCRIPTION
Currently the mason packages node-osrm builds against are built with `GLIBCXX_USE_CXX11_ABI=0`. Setting this same value in the osrm-backend and node-osrm build ensures we are consistently building against the same libstdc++ ABI and protects against compilers or systems with alternative defaults.

Note: In the future we can easily move to `GLIBCXX_USE_CXX11_ABI=1` if mason packages are available and built with that setting.