### PR TITLE
Ensure correct linking order of dependent libs

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,8 @@
           './src/'
       ],
       'libraries': [
-        '<!@(pkg-config libosrm --libs --static)'
+        '<!@(pkg-config libosrm --libs)',
+        '<!@(pkg-config libosrm --static --libs-only-other)'
       ],
       'defines': ['LIBOSRM_GIT_REVISION="<!@(pkg-config libosrm --modversion)"'],
       'conditions': [
@@ -29,9 +30,7 @@
               '<!@(pkg-config libosrm --cflags)'
           ],
           'libraries':[
-              '-Wl,-rpath=<!@(pkg-config libosrm --variable=libdir)',
-              '-lboost_program_options',
-              '-lboost_regex'
+              '-Wl,-rpath=<!@(pkg-config libosrm --variable=libdir)'
           ]}
         ],
         ['OS=="mac"', {


### PR DESCRIPTION
https://github.com/Project-OSRM/osrm-backend/pull/3130 fixed the pkg-config results for osrm-backend such that libraries are ordered in a descending way: if `liba` depends on `libb` the linking order is `-la -lb`. This is required by the linux linker when using static libraries and not wrapping in `-Wl,--start-group`.

Now we need to clean up node-osrm. This PR ensures that `-losrm` comes before dependent libs and removes the extra additions of `-lboost_program_options` and `-lboost_regex` which are no longer needed now that osrm-backend provides a consistent and correct order.

This fixes the error of `node: symbol lookup error: /home/ubuntu/node-osrm/lib/binding/osrm.node: undefined symbol: _ZN5boost10filesystem6detail19temp_directory_pathEPNS_6system10error_codeE
` which started happening on linux because `-losrm` was coming before `-lboost_filesystem` previously.