### PR TITLE
Fix linking for libs-only-l

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,8 +14,9 @@
           './src/'
       ],
       'libraries': [
-        '<!@(pkg-config libosrm --libs)',
-        '<!@(pkg-config libosrm --static --libs-only-other)'
+        '<!@(pkg-config libosrm --libs-only-L)',
+        '<!@(pkg-config libosrm --libs-only-l --static)',
+        '<!@(pkg-config libosrm --libs-only-other --static)'
       ],
       'defines': ['LIBOSRM_GIT_REVISION="<!@(pkg-config libosrm --modversion)"'],
       'conditions': [

--- a/test/data/data.md5sum
+++ b/test/data/data.md5sum
@@ -1,5 +1,5 @@
-833f482fc35f34b0cc2a82db57fd519f  car.lua
-997270b082774ecc179ccb504a59e87c  lib/destination.lua
+8fb044d64f8b2e046afe779a08ed12e8  car.lua
+60c269e554a733aacb7dc50004e5cb80  lib/destination.lua
 011ac454d10f0ff0194e4928d6f9c348  lib/access.lua
-c7ee15d26d403d20710cfa8ac1b1144c  lib/guidance.lua
+f4a7506c5deae9fe3ccb42f791420682  lib/guidance.lua
 045af81d07eb9f22e5718db13cf337e4  berlin-latest.osm.pbf

--- a/test/data/data.md5sum
+++ b/test/data/data.md5sum
@@ -1,5 +1,5 @@
-74c04fa4e09107f7ba81b1e3a0cd5923  car.lua
-60c269e554a733aacb7dc50004e5cb80  lib/destination.lua
+833f482fc35f34b0cc2a82db57fd519f  car.lua
+997270b082774ecc179ccb504a59e87c  lib/destination.lua
 011ac454d10f0ff0194e4928d6f9c348  lib/access.lua
-f4a7506c5deae9fe3ccb42f791420682  lib/guidance.lua
+c7ee15d26d403d20710cfa8ac1b1144c  lib/guidance.lua
 045af81d07eb9f22e5718db13cf337e4  berlin-latest.osm.pbf


### PR DESCRIPTION
Fixes #266. This fix in master will allow the `5.4` branch to gain `master` fixes and still build and link correctly against osrm-backend `5.4`.

Note: the md5sum update is unrelated to the linking fix and is due to #265