### PR TITLE
[WIP] try continous binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "https://github.com/Project-OSRM/node-osrm",
   "homepage": "http://project-osrm.org",
   "author": "Dane Springmeyer <springmeyer>",
-  "version": "5.4.0",
+  "version": "5.5.0-master",
   "osrm_release" : "master",
   "main": "./lib/osrm.js",
   "license": "BSD-2-Clause",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -27,8 +27,8 @@ if [[ $(uname -s) == 'Linux' ]]; then
     fi
 fi
 
-PACKAGE_VERSION=$(node -e "console.log(require('../../package.json').version)")
-OSRM_VERSION=$(node -e "console.log(require('../../package.json').osrm_version)")
+PACKAGE_VERSION=$(node -e "console.log(require('../package.json').version)")
+OSRM_VERSION=$(node -e "console.log(require('../package.json').osrm_version)")
 echo "determining publishing status for ${PACKAGE_VERSION} using OSRM ${OSRM_VERSION} ..."
 
 if [[ $(./scripts/is_pr_merge.sh) ]]; then
@@ -47,7 +47,7 @@ else
         echo "*** Error: Republishing is disallowed for this repository"
         exit 1
         #./node_modules/.bin/node-pre-gyp unpublish publish ${NPM_FLAGS}
-    elif [[ ${TRAVIS_EVENT_TYPE} == 'chron' && ${PACKAGE_VERSION} == ${MASTER_VERSION} && ${OSRM_VERSION} == "master"]]; then
+    elif [[ ${TRAVIS_EVENT_TYPE} == 'chron' && ${PACKAGE_VERSION} =~ .*-master && ${OSRM_VERSION} == "master"]]; then
         echo "Would allow republishing!"
     else
         echo "Skipping publishing"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -27,7 +27,9 @@ if [[ $(uname -s) == 'Linux' ]]; then
     fi
 fi
 
-echo "determining publishing status..."
+PACKAGE_VERSION=$(node -e "console.log(require('../../package.json').version)")
+OSRM_VERSION=$(node -e "console.log(require('../../package.json').osrm_version)")
+echo "determining publishing status for ${PACKAGE_VERSION} using OSRM ${OSRM_VERSION} ..."
 
 if [[ $(./scripts/is_pr_merge.sh) ]]; then
     echo "Skipping publishing because this is a PR merge commit"
@@ -45,6 +47,8 @@ else
         echo "*** Error: Republishing is disallowed for this repository"
         exit 1
         #./node_modules/.bin/node-pre-gyp unpublish publish ${NPM_FLAGS}
+    elif [[ ${TRAVIS_EVENT_TYPE} == 'chron' && ${PACKAGE_VERSION} == ${MASTER_VERSION} && ${OSRM_VERSION} == "master"]]; then
+        echo "Would allow republishing!"
     else
         echo "Skipping publishing"
     fi;


### PR DESCRIPTION
Move on implementing #203. This doesn't use the latest branch but master to ensure visibility of failing builds.

Sadly I didn't find a good way yet to include the date in the binary version. Current plan is to use `{OSRM_VERSION}-master` (e.g. `5.5.0-master`) as the package and binary version.