### PR TITLE
Upgrades LLVM 3.8.1 -> LLVM 3.9.1

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ export DEPS_DIR="$(pwd)/deps"
 export PATH=${DEPS_DIR}/bin:${PATH}
 mkdir -p ${DEPS_DIR}
 
-export CLANG_VERSION="${CLANG_VERSION:-3.8.1}"
+export CLANG_VERSION="${CLANG_VERSION:-3.9.1}"
 export CCACHE_VERSION=3.3.1
 export CMAKE_VERSION=3.6.2
 


### PR DESCRIPTION
LLVM 3.9.1 is now packaged in mason: https://github.com/mapbox/mason/issues/308
Upgrade our Clang compiler to the latest stable release.

In osrm: https://github.com/Project-OSRM/osrm-backend/pull/3526