### PR TITLE
Enables link-time optimized builds for osrm binaries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ node_modules: package.json
 build/%/node-osrm.node: ./node_modules
 	mkdir -p build &&\
 	 cd build &&\
-	 cmake .. -DCMAKE_BUILD_TYPE=$* -DBUILD_LIBOSRM=On &&\
+	 cmake .. -DCMAKE_BUILD_TYPE=$* -DBUILD_LIBOSRM=On -DENABLE_LTO=ON &&\
 	 VERBOSE=1 make -j${JOBS} &&\
 	 cd ..
 


### PR DESCRIPTION
The default just flipped from on to off upstream.
Re-enables LTO. See https://github.com/Project-OSRM/osrm-backend/pull/3524.

I _think_ this is the only location where we're invoking cmake to build libosrm. The coverage build below does not benefit from lto so I left it out. Does this look reasonable to you?