### PR TITLE
Syncs profile lib lua files with upstream

### DIFF
--- a/profiles/Makefile
+++ b/profiles/Makefile
@@ -6,7 +6,7 @@ endif
 
 PROFILES_URL:=https://raw.githubusercontent.com/Project-OSRM/osrm-backend/$(OSRM_RELEASE)/profiles
 
-all: car.lua bicycle.lua foot.lua lib/access.lua lib/destination.lua lib/guidance.lua lib/set.lua lib/sequence.lua lib/directional.lua
+all: car.lua bicycle.lua foot.lua lib/access.lua lib/destination.lua lib/guidance.lua lib/handlers.lua lib/sequence.lua lib/set.lua lib/tags.lua
 
 ./lib:
 	mkdir -p lib


### PR DESCRIPTION
Syncs Lua files for @emiltin's changes in https://github.com/Project-OSRM/osrm-backend/pull/3615.

Btw I just had a look at our lib files and it seems like
https://github.com/Project-OSRM/osrm-backend/blob/master/profiles/lib/maxspeed.lua
is dead code (?)