### PR TITLE
Disables LTO by Default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ node_modules: package.json
 build/%/node-osrm.node: ./node_modules
 	mkdir -p build &&\
 	 cd build &&\
-	 cmake .. -DCMAKE_BUILD_TYPE=$* -DBUILD_LIBOSRM=On -DENABLE_LTO=On &&\
+	 cmake .. -DCMAKE_BUILD_TYPE=$* -DBUILD_LIBOSRM=On -DENABLE_LTO=Off &&\
 	 VERBOSE=1 make -j${JOBS} &&\
 	 cd ..
 


### PR DESCRIPTION
We need to fix our LTO situation. @springmeyer @TheMarex you've been discussing this in https://github.com/Project-OSRM/node-osrm/issues/291#issuecomment-282084806 already. Today the LTO issue hit me when trying to resolve https://github.com/Project-OSRM/node-osrm/issues/300.

`make` will build a local `osrm-backend` with `ENABLE_LTO=On`. Mason builds its binaries with Clang. It seems like those two conditions do not go well together. I tested this with gcc49 and gcc63. Below is a small example of the linker issues I'm seeing.

Disabling LTO for the local `osrm-backend` build when using gcc works just fine.

Note: at the moment I simply disable LTO completely - how should we handle this?

---

```
cd /tmp/node-osrm/build/deps/osrm-backend-Release && ccache /home/daniel/gcc-dev-6.3/bin/g++   -DBOOST_FILESYSTEM_NO_DEPRECATED -DBOOST_RESULT_OF_USE_DECLTYPE -DBOOST_SPIRIT_USE_PHOENIX_V3 -DOSRM_PROJECT_DIR=\"/tm
p/node-osrm/deps/osrm-backend-Release\" -DPROTOZERO_STRICT_API -I/tmp/node-osrm/deps/osrm-backend-Release/include -I/tmp/node-osrm/build/deps/osrm-backend-Release/include -isystem /tmp/node-osrm/deps/osrm-backend-
Release/third_party/variant/include -isystem /tmp/node-osrm/deps/osrm-backend-Release/third_party/sol2 -isystem /tmp/node-osrm/deps/osrm-backend-Release/third_party/libosmium/include -isystem /tmp/node-osrm/mason_
packages/headers/boost/1.63.0/include -isystem /tmp/node-osrm/mason_packages/linux-x86_64/stxxl/1.4.1-1/include -isystem /tmp/node-osrm/mason_packages/linux-x86_64/expat/2.2.0/include -isystem /tmp/node-osrm/mason
_packages/linux-x86_64/lua/5.2.4/include -isystem /tmp/node-osrm/mason_packages/linux-x86_64/bzip2/1.0.6/include -isystem /tmp/node-osrm/mason_packages/linux-x86_64/tbb/2017_20161128/include  -D_GLIBCXX_USE_CXX11_
ABI=0 -flto=4 -Wall -Wextra -pedantic -Wuninitialized -Wunreachable-code -Wstrict-overflow=1 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fdiagnostics-color=auto -fPIC -ftemplate-depth=1024 -std=c++1y -D_GLIBCXX_USE_CXX
11_ABI=0 -fopenmp -O3 -DNDEBUG   -o CMakeFiles/ENGINE.dir/src/engine/guidance/lane_processing.cpp.o -c /tmp/node-osrm/deps/osrm-backend-Release/src/engine/guidance/lane_processing.cpp
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(cmdline.o):libs/program_options/src/cmdline.cpp:function boost::program_options::detail::cmdline::run(): error: u
ndefined reference to 'boost::program_options::basic_option<char>::~basic_option()'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(cmdline.o):libs/program_options/src/cmdline.cpp:function boost::program_options::detail::cmdline::run(): error: u
ndefined reference to 'boost::program_options::basic_option<char>::basic_option(boost::program_options::basic_option<char> const&)'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(cmdline.o):libs/program_options/src/cmdline.cpp:function boost::program_options::detail::cmdline::run(): error: u
ndefined reference to 'boost::program_options::basic_option<char>::~basic_option()'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(cmdline.o):libs/program_options/src/cmdline.cpp:function boost::program_options::detail::cmdline::run(): error: u
ndefined reference to 'boost::program_options::basic_option<char>::basic_option(boost::program_options::basic_option<char> const&)'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(cmdline.o):libs/program_options/src/cmdline.cpp:function boost::program_options::detail::cmdline::run(): error: u
ndefined reference to 'boost::program_options::basic_option<char>::~basic_option()'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(cmdline.o):libs/program_options/src/cmdline.cpp:function boost::program_options::detail::cmdline::run(): error: u
ndefined reference to 'boost::program_options::basic_option<char>::basic_option(boost::program_options::basic_option<char> const&)'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(cmdline.o):libs/program_options/src/cmdline.cpp:function boost::program_options::detail::cmdline::run(): error: u
ndefined reference to 'boost::program_options::basic_option<char>::~basic_option()'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(cmdline.o):libs/program_options/src/cmdline.cpp:function boost::program_options::detail::cmdline::handle_addition
al_parser(std::vector<std::string, std::allocator<std::string> >&): error: undefined reference to 'boost::program_options::basic_option<char>::basic_option(boost::program_options::basic_option<char> const&)'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(options_description.o):libs/program_options/src/options_description.cpp:function boost::detail::shared_count::sha
red_count<boost::program_options::options_description>(boost::program_options::options_description*): error: undefined reference to 'boost::program_options::options_description::~options_description()'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(options_description.o):libs/program_options/src/options_description.cpp:function boost::detail::sp_counted_impl_p
<boost::program_options::options_description>::dispose(): error: undefined reference to 'boost::program_options::options_description::~options_description()'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(variables_map.o):libs/program_options/src/variables_map.cpp:function boost::program_options::variables_map::get(s
td::string const&) const: error: undefined reference to 'boost::program_options::variable_value::~variable_value()'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(value_semantic.o):libs/program_options/src/value_semantic.cpp:function boost::program_options::invalid_option_val
ue::invalid_option_value(std::string const&): error: undefined reference to 'boost::program_options::validation_error::validation_error(boost::program_options::validation_error::kind_t, std::string const&, std::st
ring const&, int)'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(value_semantic.o):libs/program_options/src/value_semantic.cpp:function boost::program_options::invalid_option_val
ue::invalid_option_value(std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&): error: undefined reference to 'boost::program_options::validation_error::validation_error(boost::pr
ogram_options::validation_error::kind_t, std::string const&, std::string const&, int)'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(value_semantic.o):libs/program_options/src/value_semantic.cpp:function boost::program_options::invalid_bool_value
::invalid_bool_value(std::string const&): error: undefined reference to 'boost::program_options::validation_error::validation_error(boost::program_options::validation_error::kind_t, std::string const&, std::string
 const&, int)'
../../../mason_packages/linux-x86_64/boost_libprogram_options/1.63.0/lib/libboost_program_options.a(value_semantic.o):libs/program_options/src/value_semantic.cpp:function std::basic_string<wchar_t, std::char_trait
s<wchar_t>, std::allocator<wchar_t> > const& boost::program_options::validators::get_single_string<wchar_t>(std::vector<std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >, std::allocat
or<std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > > > const&, bool): error: undefined reference to 'boost::program_options::validation_error::validation_error(boost::program_option
s::validation_error::kind_t, std::string const&, std::string const&, int)'

```